### PR TITLE
Support for configuring rabbitmq_shovel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ The path to write the RabbitMQ configuration file to.
 
 Boolean to enable or disable stomp.
 
+####`config_shovel`
+
+Boolean to enable or disable shovel.
+
+####`config_shovel_statics`
+
+Hash of static shovel configurations
+
 ####`config_variables`
 
 To set config variables in rabbitmq.config

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,8 @@ class rabbitmq::config {
   $config_cluster             = $rabbitmq::config_cluster
   $config_path                = $rabbitmq::config_path
   $config_stomp               = $rabbitmq::config_stomp
+  $config_shovel              = $rabbitmq::config_shovel
+  $config_shovel_statics      = $rabbitmq::config_shovel_statics
   $default_user               = $rabbitmq::default_user
   $default_pass               = $rabbitmq::default_pass
   $env_config                 = $rabbitmq::env_config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,8 @@ class rabbitmq(
   $config_cluster             = $rabbitmq::params::config_cluster,
   $config_path                = $rabbitmq::params::config_path,
   $config_stomp               = $rabbitmq::params::config_stomp,
+  $config_shovel              = $rabbitmq::params::config_shovel,
+  $config_shovel_statics      = $rabbitmq::params::config_shovel_statics,
   $default_user               = $rabbitmq::params::default_user,
   $default_pass               = $rabbitmq::params::default_pass,
   $delete_guest_user          = $rabbitmq::params::delete_guest_user,
@@ -70,6 +72,8 @@ class rabbitmq(
   validate_absolute_path($config_path)
   validate_bool($config_cluster)
   validate_bool($config_stomp)
+  validate_bool($config_shovel)
+  validate_hash($config_shovel_statics)
   validate_string($default_user)
   validate_string($default_pass)
   validate_bool($delete_guest_user)
@@ -130,9 +134,9 @@ class rabbitmq(
     include '::rabbitmq::install::rabbitmqadmin'
 
     rabbitmq_plugin { 'rabbitmq_management':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
+      ensure   => present,
+      require  => Class['rabbitmq::install'],
+      notify   => Class['rabbitmq::service'],
       provider => 'rabbitmqplugins'
     }
 
@@ -154,6 +158,24 @@ class rabbitmq(
       require  => Class['rabbitmq::install'],
       notify   => Class['rabbitmq::service'],
       provider => 'rabbitmqplugins',
+    }
+  }
+
+  if ($config_shovel) {
+    rabbitmq_plugin { 'rabbitmq_shovel':
+      ensure   => present,
+      require  => Class['rabbitmq::install'],
+      notify   => Class['rabbitmq::service'],
+      provider => 'rabbitmqplugins',
+    }
+
+    if ($admin_enable) {
+      rabbitmq_plugin { 'rabbitmq_shovel_management':
+        ensure   => present,
+        require  => Class['rabbitmq::install'],
+        notify   => Class['rabbitmq::service'],
+        provider => 'rabbitmqplugins',
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,8 @@ class rabbitmq::params {
   $config_cluster             = false
   $config_path                = '/etc/rabbitmq/rabbitmq.config'
   $config_stomp               = false
+  $config_shovel              = false
+  $config_shovel_statics      = {}
   $default_user               = 'guest'
   $default_pass               = 'guest'
   $delete_guest_user          = false

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -313,6 +313,58 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'configuring shovel plugin' do
+        let :params do
+          {
+            :config_shovel => true
+          }
+        end
+
+        it { should contain_rabbitmq_plugin('rabbitmq_shovel') }
+
+        it { should contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+
+        describe 'with admin_enable false' do
+          let :params do
+            {
+              :config_shovel => true,
+              :admin_enable  => false
+            }
+          end
+
+          it { should_not contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+        end
+
+        describe 'with static shovels' do
+          let :params do
+            {
+              :config_shovel => true,
+              :config_shovel_statics => {
+                'shovel_first' => %q({sources,[{broker,"amqp://"}]},
+        {destinations,[{broker,"amqp://site1.example.com"}]},
+        {queue,<<"source_one">>}),
+                'shovel_second' => %q({sources,[{broker,"amqp://"}]},
+        {destinations,[{broker,"amqp://site2.example.com"}]},
+        {queue,<<"source_two">>})
+              }
+            }
+          end
+
+          it "should generate correct configuration" do
+            verify_contents(subject, 'rabbitmq.config', [
+'  {rabbitmq_shovel,',
+'    [{shovels,[',
+'      {shovel_first,[{sources,[{broker,"amqp://"}]},',
+'        {destinations,[{broker,"amqp://site1.example.com"}]},',
+'        {queue,<<"source_one">>}]},',
+'      {shovel_second,[{sources,[{broker,"amqp://"}]},',
+'        {destinations,[{broker,"amqp://site2.example.com"}]},',
+'        {queue,<<"source_two">>}]}',
+'    ]}]}' ])
+          end
+        end 
+      end
+
       describe 'default_user and default_pass set' do
         let(:params) {{ :default_user => 'foo', :default_pass => 'bar' }}
         it 'should set default_user and default_pass to specified values' do

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -52,5 +52,11 @@
     {log, <%= @ldap_log %>}
   ]}
 <%- end -%>
+<%- if @config_shovel and not @config_shovel_statics.empty? -%>,
+  {rabbitmq_shovel,
+    [{shovels,[
+      <%= @config_shovel_statics.sort.map{|k,v| "{#{k},[#{v}]}"}.join(",\n      ") %>
+    ]}]}
+<%- end -%>
 ].
 % EOF


### PR DESCRIPTION
Adding support for enabling the [Shovel plugin](https://www.rabbitmq.com/shovel.html)

Configuration of static shovels is possible using the `config_shovel_statics` parameter.

```puppet
class { 'rabbitmq' :
  config_shovel         => true,
  config_shovel_statics => {
    'site_to_site' => '{sources,[{broker,"amqp://"}]},
        {destinations,[{broker,"amqp://dr.example.com"}]},
        {queue,<<"to_offsite">>}'
  },
}
```