### PR TITLE
Added ulimit support for RabbitMQ which was restricted to 4096 file descriptors

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,6 +83,16 @@ class rabbitmq::config {
     notify  => Class['rabbitmq::service'],
   }
 
+  if $::osfamily == 'Debian' {
+    file { '/etc/default/rabbitmq-server':
+      ensure => file,
+      content => template('rabbitmq/default.erb'),
+      mode    => 0644,
+      owner   => '0',
+      group   => '0',
+      notify  => Class['rabbitmq::service'],
+    }
+  }
 
   if $config_cluster {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class rabbitmq(
   $version                    = $rabbitmq::params::version,
   $wipe_db_on_cookie_change   = $rabbitmq::params::wipe_db_on_cookie_change,
   $cluster_partition_handling = $rabbitmq::params::cluster_partition_handling,
+  $ulimit                     = $rabbitmq::params::ulimit,
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
@@ -82,6 +83,7 @@ class rabbitmq(
   validate_re($port, ['\d+','UNSET'])
   validate_re($stomp_port, '\d+')
   validate_bool($wipe_db_on_cookie_change)
+  validate_re($ulimit, '\d+')
   # Validate service parameters.
   validate_re($service_ensure, '^(running|stopped)$')
   validate_bool($service_manage)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -94,4 +94,5 @@ class rabbitmq::params {
   $environment_variables      = {}
   $config_variables           = {}
   $config_kernel_variables    = {}
+  $ulimit                     = 4096
 }

--- a/templates/default.erb
+++ b/templates/default.erb
@@ -1,0 +1,10 @@
+# File managed by Puppet.
+
+# This file is sourced by /etc/init.d/rabbitmq-server. Its primary
+# reason for existing is to allow adjustment of system limits for the
+# rabbitmq-server process.
+#
+# Maximum number of open file handles. This will need to be increased
+# to handle many simultaneous connections. Refer to the system
+# documentation for ulimit (in man bash) for more information.
+ulimit -n <%= @ulimit %>


### PR DESCRIPTION
Likely none using this library under Debian had more than 4096 connections to RabbitMQ.

By default, this library does not control ulimit settings for RabbitMQ, fallbacking to system default which is 4096 file descriptors. This patch solves this problem under Debian and is well tested in production with over 24k connections successfully. =)