### PR TITLE
Features/gentoo support

### DIFF
--- a/lib/facter/rabbitmq_erlang_cookie.rb
+++ b/lib/facter/rabbitmq_erlang_cookie.rb
@@ -4,7 +4,7 @@
 #
 # Resolution: Returns the cookie.
 Facter.add(:rabbitmq_erlang_cookie) do
-  confine :osfamily => %w[Debian RedHat Suse]
+  confine :osfamily => %w[Debian RedHat Suse Gentoo]
 
   setcode do
     if File.exists?('/var/lib/rabbitmq/.erlang.cookie')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@ class rabbitmq::config {
   $cluster_nodes              = $rabbitmq::cluster_nodes
   $config                     = $rabbitmq::config
   $config_cluster             = $rabbitmq::config_cluster
+  $config_owner               = $rabbitmq::config_owner
   $config_path                = $rabbitmq::config_path
   $config_stomp               = $rabbitmq::config_stomp
   $default_user               = $rabbitmq::default_user
@@ -51,14 +52,14 @@ class rabbitmq::config {
 
   file { '/etc/rabbitmq':
     ensure  => directory,
-    owner   => '0',
+    owner   => 'rabbitmq',
     group   => '0',
     mode    => '0644',
   }
 
   file { '/etc/rabbitmq/ssl':
     ensure  => directory,
-    owner   => '0',
+    owner   => $config_owner,
     group   => '0',
     mode    => '0644',
   }
@@ -67,7 +68,7 @@ class rabbitmq::config {
     ensure  => file,
     path    => $config_path,
     content => template($config),
-    owner   => '0',
+    owner   => $config_owner,
     group   => '0',
     mode    => '0644',
     notify  => Class['rabbitmq::service'],
@@ -77,7 +78,7 @@ class rabbitmq::config {
     ensure  => file,
     path    => $env_config_path,
     content => template($env_config),
-    owner   => '0',
+    owner   => $config_owner,
     group   => '0',
     mode    => '0644',
     notify  => Class['rabbitmq::service'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,13 @@ class rabbitmq::params {
       # This must remain at the end as we need $base_version and $version defined first.
       $package_source   = "http://www.rabbitmq.com/releases/rabbitmq-server/v${base_version}/rabbitmq-server-${version}.noarch.rpm"
     }
+    'Gentoo': {
+      $package_ensure   = 'installed'
+      $package_name     = 'rabbitmq-server'
+      $service_name     = 'rabbitmq'
+      $version          = '3.3.4'
+      $base_version     = regsubst($version,'^(.*)-\d$','\1')
+    }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class rabbitmq::params {
       $version          = '3.1.3-1'
       $base_version     = regsubst($version,'^(.*)-\d$','\1')
       # This must remain at the end as we need $base_version and $version defined first
+      $config_owner     = 'root'
     }
     'Debian': {
       $package_ensure   = 'installed'
@@ -21,6 +22,7 @@ class rabbitmq::params {
       $package_provider = 'apt'
       $package_source   = ''
       $version          = '3.1.5'
+      $config_owner     = 'root'
     }
     'RedHat': {
       $package_ensure   = 'installed'
@@ -31,6 +33,7 @@ class rabbitmq::params {
       $base_version     = regsubst($version,'^(.*)-\d$','\1')
       # This must remain at the end as we need $base_version and $version defined first.
       $package_source   = "http://www.rabbitmq.com/releases/rabbitmq-server/v${base_version}/rabbitmq-server-${version}.noarch.rpm"
+      $config_owner     = 'root'
     }
     'SUSE': {
       $package_ensure   = 'installed'
@@ -41,13 +44,14 @@ class rabbitmq::params {
       $base_version     = regsubst($version,'^(.*)-\d$','\1')
       # This must remain at the end as we need $base_version and $version defined first.
       $package_source   = "http://www.rabbitmq.com/releases/rabbitmq-server/v${base_version}/rabbitmq-server-${version}.noarch.rpm"
+      $config_owner     = 'root'
     }
     'Gentoo': {
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq-server'
       $service_name     = 'rabbitmq'
       $version          = '3.3.4'
-      $base_version     = regsubst($version,'^(.*)-\d$','\1')
+      $config_owner     = 'rabbitmq'
     }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")


### PR DESCRIPTION
Adds the tweaks needed to enable this module to be deployed on Gentoo-type distributions. Rabbitmq::Params needs a Gentoo block to avoid the compilation fail, and config files/dirs need to be owned by the package-created rabbitmq user to allow rabbitmq-plugin to make changes.