### PR TITLE
Make the config class slightly more strict variables compliant

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -103,7 +103,7 @@ class rabbitmq::config {
     }
 
     # rabbitmq_erlang_cookie is a fact in this module.
-    if $erlang_cookie != $::rabbitmq_erlang_cookie {
+    if $erlang_cookie != getvar('::rabbitmq_erlang_cookie') {
       # Safety check.
       if $wipe_db_on_cookie_change {
         exec { 'wipe_db':


### PR DESCRIPTION
I run this module under the strict variables mode.

This change makes it work under strict variables mode in the case where the cookie doesn't exist yet.

I tried running the tests under strict variables mode, and 135 of them failed :( So it's not quite ready to be *test* under that mode, but at least it will *run*.