### PR TITLE
Make rabbitmqctl provider to wait for rabbitmq cluster

### DIFF
--- a/lib/puppet/provider/rabbitmq_common.rb
+++ b/lib/puppet/provider/rabbitmq_common.rb
@@ -1,0 +1,47 @@
+class Puppet::Provider::Rabbitmq_common < Puppet::Provider
+  initvars
+  commands :rabbitmqctl => 'rabbitmqctl'
+
+  # Wait 'count*step' seconds while RabbitMQ is ready (able to list its users&channels)
+  # Make 'count' retries with 'step' delay between retries.
+  # Limit each query time by 'timeout'
+  def self.wait_for_online(count=30, step=6, timeout=10)
+    count.times do |n|
+      begin
+        # Note, that then RabbitMQ cluster is broken or not ready, it might not show its
+        # channels some times and hangs for ever, so we have to specify a timeout as well
+        Timeout::timeout(timeout) do
+          rabbitmqctl 'status'
+        end
+      rescue Puppet::ExecutionFailure, Timeout
+        Puppet.debug 'RabbitMQ is not ready, retrying'
+        sleep step
+      else
+        Puppet.debug "RabbitMQ is online after #{n * step} seconds"
+        return true
+      end
+    end
+    raise Puppet::Error, "RabbitMQ is not ready after #{count * step} seconds expired!"
+  end
+
+  # retry the given code block until command suceeeds
+  # for example:
+  # users = self.class.run_with_retries { rabbitmqctl 'list_users' }
+  def self.run_with_retries(count=30, step=6, timeout=10)
+    count.times do |n|
+      begin
+        output = Timeout::timeout(timeout) do
+          yield
+        end
+      rescue Puppet::ExecutionFailure, Timeout
+        Puppet.debug 'Command failed, retrying'
+        sleep step
+      else
+        Puppet.debug 'Command succeeded'
+        return output
+      end
+    end
+    raise Puppet::Error, "Command is still failing after #{count * step} seconds expired!"
+  end
+
+end

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -1,6 +1,7 @@
 require 'puppet'
 require 'set'
-Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
+require File.join File.dirname(__FILE__), '../rabbitmq_common.rb'
+Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl, :parent => Puppet::Provider::Rabbitmq_common) do
 
   if Puppet::PUPPETVERSION.to_f < 3
     commands :rabbitmqctl => 'rabbitmqctl'
@@ -13,7 +14,10 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   defaultfor :feature => :posix
 
   def self.instances
-    rabbitmqctl('-q', 'list_users').split(/\n/).collect do |line|
+    self.wait_for_online
+    self.run_with_retries {
+      rabbitmqctl('-q', 'list_users')
+    }.split(/\n/).collect do |line|
       if line =~ /^(\S+)(\s+\[.*?\]|)$/
         new(:name => $1)
       else
@@ -55,12 +59,15 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   end
 
   def exists?
-    rabbitmqctl('-q', 'list_users').split(/\n/).detect do |line|
+    self.class.wait_for_online
+    out = self.class.run_with_retries {
+      rabbitmqctl('-q', 'list_users')
+    }.split(/\n/).detect do |line|
       line.match(/^#{Regexp.escape(resource[:name])}(\s+(\[.*?\]|\S+)|)$/)
     end
   end
 
- 
+
   def tags
     get_user_tags.entries.sort
   end

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -10,6 +10,8 @@ describe provider_class do
       {:name => 'foo', :password => 'bar'}
     )
     @provider = provider_class.new(@resource)
+    @provider.class.stubs(:wait_for_online).returns(true)
+    @provider
   end
   it 'should match user names' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
@@ -99,7 +101,7 @@ icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz', 'administrator'].sort) 
+    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz', 'administrator'].sort)
     @provider.admin=:true
   end
   it 'should be able to unset admin value' do
@@ -118,7 +120,7 @@ icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz'].sort) 
+    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz'].sort)
     @provider.admin=:false
   end
 

--- a/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
@@ -10,6 +10,8 @@ describe 'Puppet::Type.type(:rabbitmq_user_permissions).provider(:rabbitmqctl)' 
       {:name => 'foo@bar'}
     )
     @provider = @provider_class.new(@resource)
+    @provider.class.stubs(:wait_for_online).returns(true)
+    @provider
   end
   after :each do
     @provider_class.instance_variable_set(:@users, nil)
@@ -41,13 +43,13 @@ EOT
     @provider.instance_variable_set(:@should_vhost, "bar")
     @provider.instance_variable_set(:@should_user, "foo")
     @provider.expects(:rabbitmqctl).with('set_permissions', '-p', 'bar', 'foo', "''", "''", "''")
-    @provider.create 
+    @provider.create
   end
   it 'should destroy permissions' do
     @provider.instance_variable_set(:@should_vhost, "bar")
     @provider.instance_variable_set(:@should_user, "foo")
     @provider.expects(:rabbitmqctl).with('clear_permissions', '-p', 'bar', 'foo')
-    @provider.destroy 
+    @provider.destroy
   end
   {:configure_permission => '1', :write_permission => '2', :read_permission => '3'}.each do |k,v|
     it "should be able to retrieve #{k}" do

--- a/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
@@ -10,6 +10,8 @@ describe provider_class do
       {:name => 'foo'}
     )
     @provider = provider_class.new(@resource)
+    @provider.class.stubs(:wait_for_online).returns(true)
+    @provider
   end
   it 'should match vhost names' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT


### PR DESCRIPTION
W/o this fix, then RabbitMQ put in a cluster and managed
by Pacemaker, rabbitmqctl could fail its requests due
to cluster is not ready yet.

The solution is:
1) Introduce a base Rabbitmq_common provider class with wait_online method
and a retry decorator for rabbitmqctl commands to ensure they will retry
instead of fail then cluster is not ready.
3) Derive rabbitmqctl provider classes from the former one to make
them able to wait for RabbitMQ reasy as well.
4) Update rspecs

Co-authors: Dmitry Ilyin <dilyin@mirantis.com>
Closes-bug: #MODULES-1452

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>