### PR TITLE
User tag changes for <=3.3.4

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -111,6 +111,12 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
     match = rabbitmqctl('-q', 'list_users').split(/\n/).collect do |line|
       line.match(/^#{Regexp.escape(resource[:name])}\s+\[(.*?)\]/)
     end.compact.first
-    Set.new(match[1].split(/, /)) if match
+    if match
+      # RabbitMQ 3.3.5 and up separate tags with ', '
+      # 3.3.4 just separates with space
+      # this splits by space and then strips word-final commas
+      # (if you're ending a valid tag name with a comma, why)
+      Set.new(match[1].split(' ')).map{|x| x.gsub(/,$/, '')}
+    end
   end
 end

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -111,12 +111,6 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
     match = rabbitmqctl('-q', 'list_users').split(/\n/).collect do |line|
       line.match(/^#{Regexp.escape(resource[:name])}\s+\[(.*?)\]/)
     end.compact.first
-    if match
-      # RabbitMQ 3.3.5 and up separate tags with ', '
-      # 3.3.4 just separates with space
-      # this splits by space and then strips word-final commas
-      # (if you're ending a valid tag name with a comma, why)
-      Set.new(match[1].split(' ')).map{|x| x.gsub(/,$/, '')}
-    end
+    Set.new(match[1].split(' ').map{|x| x.gsub(/,$/, '')}) if match
   end
 end


### PR DESCRIPTION
I found that RabbitMQ 3.3.4 separates tags with only a space, where 3.3.5 separates them with a comma and then a space. This works around that by first splitting tags by spaces, then stripping any word-final commas if they are present, so that it will work regardless of which way rabbitmqctl formats the tag list.

This has already been tested throughout my company's various environments, and all tests pass after this change.