### PR TITLE
Fix pin conditional

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -31,7 +31,7 @@ class rabbitmq::repo::apt(
     key_content => $key_content,
   }
 
-  if $pin {
+  if $pin != '' {
     validate_re($pin, '\d\d\d')
     apt::pin { 'rabbitmq':
       packages => 'rabbitmq-server',


### PR DESCRIPTION
Since the default value of package_apt_pin is an empty string
rather than a boolean, it was failing the conditional test in
Puppet 3.7+. This commit changes the conditional to check for an
empty string.