### PR TITLE
Added ssl_versions parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ all features against earlier versions.
 * rabbitmq configuration file.
 * rabbitmq service.
 
-###Beginning with rabbitmq  
+###Beginning with rabbitmq
 
 
 ```puppet
@@ -343,6 +343,10 @@ SSL stomp port.
 ####`ssl_verify`
 
 rabbitmq.config SSL verify setting.
+
+####`ssl_versions`
+
+Choose which SSL versions to enable. By default, sslv3, tlsv1, tlsv1.1, and tlsv1.2 are enabled. To protect against POODLE, you should disable sslv3 and tlsv1.
 
 ####`ssl_fail_if_no_peer_cert`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,6 +31,7 @@ class rabbitmq::config {
   $ssl_stomp_port             = $rabbitmq::ssl_stomp_port
   $ssl_verify                 = $rabbitmq::ssl_verify
   $ssl_fail_if_no_peer_cert   = $rabbitmq::ssl_fail_if_no_peer_cert
+  $ssl_versions               = $rabbitmq::ssl_versions
   $stomp_port                 = $rabbitmq::stomp_port
   $wipe_db_on_cookie_change   = $rabbitmq::wipe_db_on_cookie_change
   $config_variables           = $rabbitmq::config_variables

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class rabbitmq(
   $ssl_stomp_port             = $rabbitmq::params::ssl_stomp_port,
   $ssl_verify                 = $rabbitmq::params::ssl_verify,
   $ssl_fail_if_no_peer_cert   = $rabbitmq::params::ssl_fail_if_no_peer_cert,
+  $ssl_versions               = $rabbitmq::params::ssl_versions,
   $stomp_ensure               = $rabbitmq::params::stomp_ensure,
   $ldap_auth                  = $rabbitmq::params::ldap_auth,
   $ldap_server                = $rabbitmq::params::ldap_server,
@@ -98,6 +99,7 @@ class rabbitmq(
   validate_re($ssl_management_port, '\d+')
   validate_string($ssl_stomp_port)
   validate_re($ssl_stomp_port, '\d+')
+  validate_array($ssl_versions)
   validate_bool($stomp_ensure)
   validate_bool($ldap_auth)
   validate_string($ldap_server)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,6 +73,7 @@ class rabbitmq::params {
   $ssl_stomp_port             = '6164'
   $ssl_verify                 = 'verify_none'
   $ssl_fail_if_no_peer_cert   = false
+  $ssl_versions               = ['tlsv1.2', 'tlsv1.1', 'tlsv1', 'sslv3']
   $stomp_ensure               = false
   $ldap_auth                  = false
   $ldap_server                = 'ldap'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -39,7 +39,7 @@ describe 'rabbitmq' do
   context 'on Debian' do
     let(:params) {{ :manage_repos => true }}
     let(:facts) {{ :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistcodename => 'squeeze' }}
-    
+
     it 'includes rabbitmq::repo::apt' do
       should contain_class('rabbitmq::repo::apt')
     end
@@ -69,7 +69,7 @@ describe 'rabbitmq' do
   context 'on Debian' do
     let(:params) {{ :repos_ensure => true }}
     let(:facts) {{ :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistcodename => 'squeeze' }}
-    
+
     it 'includes rabbitmq::repo::apt' do
       should contain_class('rabbitmq::repo::apt')
     end
@@ -89,7 +89,7 @@ describe 'rabbitmq' do
   context 'on Debian' do
     let(:params) {{ :manage_repos => true, :repos_ensure => false }}
     let(:facts) {{ :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistcodename => 'squeeze' }}
-    
+
     it 'includes rabbitmq::repo::apt' do
       should contain_class('rabbitmq::repo::apt')
     end
@@ -106,7 +106,7 @@ describe 'rabbitmq' do
   context 'on Debian' do
     let(:params) {{ :manage_repos => true, :repos_ensure => true }}
     let(:facts) {{ :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistcodename => 'squeeze' }}
-    
+
     it 'includes rabbitmq::repo::apt' do
       should contain_class('rabbitmq::repo::apt')
     end
@@ -481,6 +481,9 @@ describe 'rabbitmq' do
           should contain_file('rabbitmq.config').with_content(
             %r{keyfile,"/path/to/key"}
           )
+          should contain_file('rabbitmq.config').with_content(
+            %r{ssl, \[\{versions, \['sslv3', 'tlsv1', 'tlsv1.1', 'tlsv1.2'\]\}\]}
+          )
         end
       end
 
@@ -500,6 +503,26 @@ describe 'rabbitmq' do
           should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[\{cacertfile,"/path/to/cacert"})
           should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
           should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
+          should contain_file('rabbitmq.config').with_content(%r{ssl, \[\{versions, \['sslv3', 'tlsv1', 'tlsv1.1', 'tlsv1.2'\]\}\]})
+        end
+      end
+
+      describe 'ssl options with specific ssl versions' do
+        let(:params) {
+          { :ssl => true,
+            :ssl_port => 3141,
+            :ssl_cacert => '/path/to/cacert',
+            :ssl_cert => '/path/to/cert',
+            :ssl_key => '/path/to/key',
+            :ssl_versions => ['tlsv1.2', 'tlsv1.1']
+        } }
+
+        it 'should set ssl options to specified values' do
+          should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[3141\]})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[\{cacertfile,"/path/to/cacert"})
+          should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
+          should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
+          should contain_file('rabbitmq.config').with_content(%r{ssl, \[\{versions, \['tlsv1.1', 'tlsv1.2'\]\}\]})
         end
       end
 

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -1,6 +1,9 @@
 % This file managed by Puppet
 % Template Path: <%= @module_name %>/templates/rabbitmq.config
 [
+<% if @ssl -%>
+  {ssl, [{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}]},
+<% end -%>
   {rabbit, [
 <% if @ldap_auth -%>
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
@@ -21,7 +24,8 @@
                     {certfile,"<%= @ssl_cert %>"},
                     {keyfile,"<%= @ssl_key %>"},
                     {verify,<%= @ssl_verify %>},
-                    {fail_if_no_peer_cert,<%= @ssl_fail_if_no_peer_cert %>}]},
+                    {fail_if_no_peer_cert,<%= @ssl_fail_if_no_peer_cert %>},
+                    {ssl, [{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}]}]},
 <%- end -%>
 <% if @config_variables -%>
 <%- @config_variables.keys.sort.each do |key| -%>


### PR DESCRIPTION
This parameter defines which ssl versions to enable in RabbitMQ.
By default, all versions reported by Erlang are enabled. This should
be the same as if this setting was not added in the first place.