### PR TITLE
Documentation update for ssl_only

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Configures the service for using SSL.
 ####`ssl_only`
 
 Configures the service to only use SSL.  No cleartext TCP listeners will be created.
-Requires that ssl => true also.
+Requires that ssl => true and port => UNSET also
 
 ####`ssl_cacert`
 


### PR DESCRIPTION
Due to the way the environment configuration works setting ssl_true does not actually disable the plaintext listener.  The tcp_listeners in the config are properly removed, but the RABBITMQ_NODE_PORT=5672 environment variable is still set which overrides the config file option and still starts up the plaintext listener on port 5672. 

Fixing the code to properly disable the env variable is most likely the "better" solution, but this workaround is simple and now documented