### PR TITLE
Add retries for non transient file transfer errors

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -15,7 +15,8 @@ class rabbitmq::install::rabbitmqadmin {
   staging::file { 'rabbitmqadmin':
     target      => '/var/lib/rabbitmq/rabbitmqadmin',
     source      => "${protocol}://${default_user}:${default_pass}@localhost:${management_port}/cli/rabbitmqadmin",
-    curl_option => '-k --noproxy localhost',
+    curl_option => '-k --noproxy localhost --retry 30 --retry-delay 6',
+    timeout     => '180',
     wget_option => '--no-proxy',
     require     => [
       Class['rabbitmq::service'],


### PR DESCRIPTION
W/o this patch, Rabbitmq::Install::Rabbitmqadmin/Staging::File[rabbitmqadmin]
/Exec[/var/lib/rabbitmq/rabbitmqadmin]
sometimes could fail the curl command due to transient or connectivity errors.

The solution is:
- For transient errors:
* use timeout param for staging::file
* use --retries , --retry-delay flag for curl command passed to staging::file
- For connectivity errors:
* improve staging module to retry its commands as well, see
  https://github.com/nanliu/puppet-staging/pull/52

Closes-bug: #MODULES-1650

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>