### PR TITLE
Fix rabbitmq-env.conf parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ To use RabbitMQ Environment Variables, use the parameters `environment_variables
 class { 'rabbitmq':
   port              => '5672',
   environment_variables   => {
-    'RABBITMQ_NODENAME'     => 'node01',
-    'RABBITMQ_SERVICENAME'  => 'RabbitMQ'
+    'NODENAME'     => 'node01',
+    'SERVICENAME'  => 'RabbitMQ'
   }
 }
 ```
@@ -261,7 +261,7 @@ The port for the RabbitMQ management interface.
 
 ####`node_ip_address`
 
-The value of RABBITMQ_NODE_IP_ADDRESS in rabbitmq_env.config
+The value of NODE_IP_ADDRESS in rabbitmq_env.config
 
 ####`package_ensure`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,8 +37,8 @@ class rabbitmq::config {
   $config_kernel_variables    = $rabbitmq::config_kernel_variables
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $default_env_variables      =  {
-    'RABBITMQ_NODE_PORT'        => $port,
-    'RABBITMQ_NODE_IP_ADDRESS'  => $node_ip_address
+    'NODE_PORT'        => $port,
+    'NODE_IP_ADDRESS'  => $node_ip_address
   }
 
   # Handle env variables.

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -323,25 +323,25 @@ describe 'rabbitmq' do
 
       describe 'rabbitmq-env configuration' do
         let(:params) {{ :environment_variables => {
-          'RABBITMQ_NODE_IP_ADDRESS'    => '1.1.1.1',
-          'RABBITMQ_NODE_PORT'          => '5656',
-          'RABBITMQ_NODENAME'           => 'HOSTNAME',
-          'RABBITMQ_SERVICENAME'        => 'RabbitMQ',
-          'RABBITMQ_CONSOLE_LOG'        => 'RabbitMQ.debug',
-          'RABBITMQ_CTL_ERL_ARGS'       => 'verbose',
-          'RABBITMQ_SERVER_ERL_ARGS'    => 'v',
-          'RABBITMQ_SERVER_START_ARGS'  => 'debug'
+          'NODE_IP_ADDRESS'    => '1.1.1.1',
+          'NODE_PORT'          => '5656',
+          'NODENAME'           => 'HOSTNAME',
+          'SERVICENAME'        => 'RabbitMQ',
+          'CONSOLE_LOG'        => 'RabbitMQ.debug',
+          'CTL_ERL_ARGS'       => 'verbose',
+          'SERVER_ERL_ARGS'    => 'v',
+          'SERVER_START_ARGS'  => 'debug'
         }}}
         it 'should set environment variables' do
           should contain_file('rabbitmq-env.config') \
-            .with_content(/RABBITMQ_NODE_IP_ADDRESS=1.1.1.1/) \
-            .with_content(/RABBITMQ_NODE_PORT=5656/) \
-            .with_content(/RABBITMQ_NODENAME=HOSTNAME/) \
-            .with_content(/RABBITMQ_SERVICENAME=RabbitMQ/) \
-            .with_content(/RABBITMQ_CONSOLE_LOG=RabbitMQ.debug/) \
-            .with_content(/RABBITMQ_CTL_ERL_ARGS=verbose/) \
-            .with_content(/RABBITMQ_SERVER_ERL_ARGS=v/) \
-            .with_content(/RABBITMQ_SERVER_START_ARGS=debug/)
+            .with_content(/NODE_IP_ADDRESS=1.1.1.1/) \
+            .with_content(/NODE_PORT=5656/) \
+            .with_content(/NODENAME=HOSTNAME/) \
+            .with_content(/SERVICENAME=RabbitMQ/) \
+            .with_content(/CONSOLE_LOG=RabbitMQ.debug/) \
+            .with_content(/CTL_ERL_ARGS=verbose/) \
+            .with_content(/SERVER_ERL_ARGS=v/) \
+            .with_content(/SERVER_START_ARGS=debug/)
         end
       end
 
@@ -364,9 +364,9 @@ describe 'rabbitmq' do
       context 'configuration setting' do
         describe 'node_ip_address when set' do
           let(:params) {{ :node_ip_address => '172.0.0.1' }}
-          it 'should set RABBITMQ_NODE_IP_ADDRESS to specified value' do
+          it 'should set NODE_IP_ADDRESS to specified value' do
             should contain_file('rabbitmq-env.config').
-              with_content(%r{RABBITMQ_NODE_IP_ADDRESS=172\.0\.0\.1})
+              with_content(%r{NODE_IP_ADDRESS=172\.0\.0\.1})
           end
         end
 


### PR DESCRIPTION
W/o this patch, env parameters from rabbitmq-env.conf
will always override the ones specified at the init file of
rabbitmq-server.

This is an issue as we may want them to differ
for separated rabbitmq instances running at the same host.

The soution is to remove RABBIT(MQ)_ prefixes for all
parameters in rabbitmq-env.conf as it described at the
man pages.

Closes-bug: #MODULES-1673

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>