### PR TITLE
SSL option in rabbitmqadmin.conf is broken

### DIFF
--- a/templates/rabbitmqadmin.conf.erb
+++ b/templates/rabbitmqadmin.conf.erb
@@ -3,6 +3,5 @@
 ssl = True
 port = <%= @ssl_management_port %>
 <% else -%>
-ssl = False
 port = <%= @management_port %>
 <% end -%>


### PR DESCRIPTION
This fixes MODULES-1691, caused by upstream bug
https://github.com/rabbitmq/rabbitmq-management/issues/20