### PR TITLE
Add retries for rabbitmqadmin curl command

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -18,6 +18,8 @@ class rabbitmq::install::rabbitmqadmin {
     curl_option => '-k --noproxy localhost --retry 30 --retry-delay 6',
     timeout     => '180',
     wget_option => '--no-proxy',
+    tries       => 30,
+    try_sleep   => 6,
     require     => [
       Class['rabbitmq::service'],
       Rabbitmq_plugin['rabbitmq_management']


### PR DESCRIPTION
W/o this patch, Rabbitmq::Install::Rabbitmqadmin
sometimes fails to install the rabbitmqadmin script if
there are some connectivity (which is non-transient) errors.

The solution is to add retries for exec command of dependency
staging module as curl allows retries only for transient errors
and fails for connectivity errors. Note, we can do it since the
dependency patch for staging module was merged
https://github.com/nanliu/puppet-staging/pull/52

Related-bug: #MODULES-1650

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>