### PR TITLE
Bugfix for ssl_versions in rabbitmq.config 

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -519,6 +519,7 @@ describe 'rabbitmq' do
           should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
           should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
           should contain_file('rabbitmq.config').with_content(%r{ssl, \[\{versions, \['tlsv1.1', 'tlsv1.2'\]\}\]})
+          should contain_file('rabbitmq.config').with_content(%r{versions, \['tlsv1.1', 'tlsv1.2'\]})
         end
       end
 
@@ -552,6 +553,29 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'ssl admin options with specific ssl versions' do
+        let(:params) {
+          { :ssl => true,
+            :ssl_management_port => 5926,
+            :ssl_cacert => '/path/to/cacert',
+            :ssl_cert => '/path/to/cert',
+            :ssl_key => '/path/to/key',
+            :ssl_versions => ['tlsv1.2', 'tlsv1.1'],
+            :admin_enable => true
+        } }
+
+        it 'should set admin ssl opts to specified values' do
+          should contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          should contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          should contain_file('rabbitmq.config').with_content(%r{port, 5926\}})
+          should contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[\{cacertfile, "/path/to/cacert"\},})
+          should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
+          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
+          should contain_file('rabbitmq.config').with_content(%r{,\{versions, \['tlsv1.1', 'tlsv1.2'\]\}[\r\n ]*\]\}})
+        end
+      end
+
       describe 'ssl admin options' do
         let(:params) {
           { :ssl => true,
@@ -569,7 +593,7 @@ describe 'rabbitmq' do
           should contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
           should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[\{cacertfile, "/path/to/cacert"\},})
           should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}\]\}})
+          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}[\r\n ]*\]\}})
         end
       end
 
@@ -604,7 +628,7 @@ describe 'rabbitmq' do
           should contain_file('rabbitmq.config').with_content(%r{ssl, true\},})
           should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[\{cacertfile, "/path/to/cacert"\},})
           should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}\]\}})
+          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}[\r\n ]*\]\}})
         end
       end
 

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -1,6 +1,9 @@
 % This file managed by Puppet
 % Template Path: <%= @module_name %>/templates/rabbitmq.config
 [
+<%- if @ssl and @ssl_versions -%>
+  {ssl, [{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}]},
+<%- end -%>
   {rabbit, [
 <% if @ldap_auth -%>
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
@@ -16,9 +19,6 @@
     {tcp_listeners, []},
 <%- end -%>
 <%- if @ssl -%>
-    <%- if @ssl_versions -%>
-      {ssl, [{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}]},
-    <%- end -%>
     {ssl_listeners, [<%= @ssl_port %>]},
     {ssl_options, [<%- if @ssl_cacert != 'UNSET' -%>{cacertfile,"<%= @ssl_cacert %>"},<%- end -%>
                     {certfile,"<%= @ssl_cert %>"},
@@ -26,7 +26,7 @@
                     {verify,<%= @ssl_verify %>},
                     {fail_if_no_peer_cert,<%= @ssl_fail_if_no_peer_cert %>}
                     <%- if @ssl_versions -%>
-                      ,{ssl, [{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}]}
+                      ,{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}
                     <% end -%>]},
 <%- end -%>
 <% if @config_variables -%>
@@ -49,7 +49,10 @@
       {ssl, true},
       {ssl_opts, [<%- if @ssl_cacert != 'UNSET' -%>{cacertfile, "<%= @ssl_cacert %>"},<%- end -%>
                   {certfile, "<%= @ssl_cert %>"},
-                  {keyfile, "<%= @ssl_key %>"}]}
+                  {keyfile, "<%= @ssl_key %>"}
+                   <%- if @ssl_versions -%>
+                     ,{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}
+                   <% end -%>]}
 <%- else -%>
       {port, <%= @management_port %>}
 <%- end -%>


### PR DESCRIPTION
RabbitMQ was not respecting this setting. The format of the configuration file was incorrect. This patch updates to bring this in line with documentation.

  The format reference example is given in https://www.rabbitmq.com/ssl.html#disabling-tls-versions
  Also add version list for rabbitmq_management config ssl_opts.
