### PR TITLE
Fix unscoped template variables

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,6 +32,12 @@ class rabbitmq::config {
   $ssl_verify                 = $rabbitmq::ssl_verify
   $ssl_fail_if_no_peer_cert   = $rabbitmq::ssl_fail_if_no_peer_cert
   $stomp_port                 = $rabbitmq::stomp_port
+  $ldap_auth                  = $rabbitmq::ldap_auth
+  $ldap_server                = $rabbitmq::ldap_server
+  $ldap_user_dn_pattern       = $rabbitmq::ldap_user_dn_pattern
+  $ldap_use_ssl               = $rabbitmq::ldap_use_ssl
+  $ldap_port                  = $rabbitmq::ldap_port
+  $ldap_log                   = $rabbitmq::ldap_log
   $wipe_db_on_cookie_change   = $rabbitmq::wipe_db_on_cookie_change
   $config_variables           = $rabbitmq::config_variables
   $config_kernel_variables    = $rabbitmq::config_kernel_variables


### PR DESCRIPTION
LDAP related variables in rabbitmq.config.erb rely
on dynamic scoping, which is discontinued in the future parser.

They need to be exposed in rabbitmq::config in order to be
accessible in the template.