### PR TITLE
Do not stop RabbitMQ before creating the Erlang Cookie

### DIFF
--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -15,7 +15,6 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
 
   def content=(value)
     if resource[:force] == :true # Danger!
-      puppet('resource', 'service', resource[:service_name], 'ensure=stopped')
       FileUtils.rm_rf('/var/lib/rabbitmq/mnesia')
       File.open(resource[:path], 'w') do |cookie|
         cookie.chmod(0400)


### PR DESCRIPTION
When boostraping a cluster, Puppet will:
* create the cookie and manage permissions
* if there is a change on this resource (create or update), thanks to
  the notify in rabbitmq::config, RabbitMQ service will be restarted by
  Puppet.

Given that, we should not manage the service in the provider itself,
since it's already done in the manifest.

This patch aims to delete the 'puppet resource' command in the
rabbitmq_erlang_cookie provider that ensured RabbitMQ service was
stopped before the cookie file management.

This patch has been tested on a new environment and an existing one, to be sure RabbitMQ is updated with the right cookie, on both use-cases.