### PR TITLE
Fixed up rabbitmq.conf file layout

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -483,7 +483,10 @@ describe 'rabbitmq' do
             %r{ssl_listeners, \[3141\]}
           )
           should contain_file('rabbitmq.config').with_content(
-            %r{ssl_options, \[\{cacertfile,"/path/to/cacert"}
+            %r{ssl_options, \[}
+          )
+          should contain_file('rabbitmq.config').with_content(
+            %r{cacertfile,"/path/to/cacert"}
           )
           should contain_file('rabbitmq.config').with_content(
             %r{certfile,"/path/to/cert"}
@@ -507,7 +510,7 @@ describe 'rabbitmq' do
 
         it 'should set ssl options to specified values' do
           should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[\{"0.0.0.0", 3141\}\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[\{cacertfile,"/path/to/cacert"})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
           should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
           should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
         end
@@ -528,7 +531,8 @@ describe 'rabbitmq' do
         it 'should set ssl options to specified values' do
           should contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\]})
           should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[3141\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[\{cacertfile,"/path/to/cacert"})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
           should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
           should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
         end
@@ -548,7 +552,7 @@ describe 'rabbitmq' do
         it 'should set ssl options to specified values' do
           should contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\]})
           should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[\{"0.0.0.0", 3141\}\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[\{cacertfile,"/path/to/cacert"})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
           should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
           should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
         end
@@ -566,7 +570,8 @@ describe 'rabbitmq' do
 
         it 'should set ssl options to specified values' do
           should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[3141\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[\{cacertfile,"/path/to/cacert"})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
           should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
           should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
           should contain_file('rabbitmq.config').with_content(%r{ssl, \[\{versions, \['tlsv1.1', 'tlsv1.2'\]\}\]})

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -26,14 +26,18 @@
   <%- else -%>
     {ssl_listeners, [<%= @ssl_port %>]},
   <%- end -%>
-    {ssl_options, [<%- if @ssl_cacert != 'UNSET' -%>{cacertfile,"<%= @ssl_cacert %>"},<%- end -%>
-                    {certfile,"<%= @ssl_cert %>"},
-                    {keyfile,"<%= @ssl_key %>"},
-                    {verify,<%= @ssl_verify %>},
-                    {fail_if_no_peer_cert,<%= @ssl_fail_if_no_peer_cert %>}
-                    <%- if @ssl_versions -%>
-                      ,{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}
-                    <% end -%>]},
+    {ssl_options, [
+                   <%- if @ssl_cacert != 'UNSET' -%>
+                   {cacertfile,"<%= @ssl_cacert %>"},
+                   <%- end -%>
+                   {certfile,"<%= @ssl_cert %>"},
+                   {keyfile,"<%= @ssl_key %>"},
+                   {verify,<%= @ssl_verify %>},
+                   {fail_if_no_peer_cert,<%= @ssl_fail_if_no_peer_cert %>}
+                   <%- if @ssl_versions -%>
+                   ,{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}
+                   <%- end -%>
+                  ]},
 <%- end -%>
 <% if @config_variables -%>
 <%- @config_variables.keys.sort.each do |key| -%>


### PR DESCRIPTION
Fixed layout of ssl_options section to make sure they are on separate
lines, making it easier to read when the file is cat'ed.