### PR TITLE
Add Support for OpenBSD and fix rabbitmq_exchange/rabbitmqadmin.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,18 @@ repository otherwise.
 
 Boolean to determine if we should DESTROY AND DELETE the RabbitMQ database.
 
+####`rabbitmq_user`
+
+String: OS dependent, default defined in param.pp. The system user the rabbitmq daemon runs as.
+
+####`rabbitmq_group`
+
+String: OS dependent, default defined in param.pp. The system group the rabbitmq daemon runs as.
+
+####`rabbitmq_home`
+
+String: OS dependent. default defined in param.pp. The home directory of the rabbitmq deamon.
+
 ##Native Types
 
 ### rabbitmq\_user
@@ -493,9 +505,9 @@ rabbitmq_plugin {'rabbitmq_stomp':
 This is essentially a private type used by the rabbitmq::config class
 to manage the erlang cookie. It replaces the rabbitmq_erlang_cookie fact
 from earlier versions of this module. It manages the content of the cookie
-usually located at /var/lib/rabbitmq/.erlang.cookie, which includes
+usually located at "${rabbitmq_home}/.erlang.cookie", which includes
 stopping the rabbitmq service and wiping out the database at
-/var/lib/rabbitmq/mnesia if the user agrees to it. We don't recommend using
+"${rabbitmq_home}/mnesia" if the user agrees to it. We don't recommend using
 this type directly.
 
 ##Limitations

--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -16,12 +16,12 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
   def content=(value)
     if resource[:force] == :true # Danger!
       puppet('resource', 'service', resource[:service_name], 'ensure=stopped')
-      FileUtils.rm_rf('/var/lib/rabbitmq/mnesia')
+      FileUtils.rm_rf(resource[:rabbitmq_home] + File::PATH_SEPARATOR + 'mnesia')
       File.open(resource[:path], 'w') do |cookie|
         cookie.chmod(0400)
         cookie.write(value)
       end
-      FileUtils.chown('rabbitmq', 'rabbitmq', resource[:path])
+      FileUtils.chown(resource[:rabbitmq_user], resource[:rabbitmq_group], resource[:path])
     else
       fail("The current erlang cookie needs to change. In order to do this the RabbitMQ database needs to be wiped.  Please set force => true to allow this to happen automatically.")
     end

--- a/lib/puppet/type/rabbitmq_erlang_cookie.rb
+++ b/lib/puppet/type/rabbitmq_erlang_cookie.rb
@@ -16,6 +16,18 @@ Puppet::Type.newtype(:rabbitmq_erlang_cookie) do
     newvalues(:true, :false)
   end
 
+  newparam(:rabbitmq_user) do
+    defaultto('rabbitmq')
+  end
+
+  newparam(:rabbitmq_group) do
+    defaultto('rabbitmq')
+  end
+
+  newparam(:rabbitmq_home) do
+    defaultto('/var/lib/rabbitmq')
+  end
+
   newparam(:service_name) do
     newvalues(/^\S+$/)
   end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class rabbitmq::config {
   $management_port            = $rabbitmq::management_port
   $node_ip_address            = $rabbitmq::node_ip_address
   $plugin_dir                 = $rabbitmq::plugin_dir
+  $rabbitmq_home              = $rabbitmq::rabbitmq_home
   $port                       = $rabbitmq::port
   $tcp_keepalive              = $rabbitmq::tcp_keepalive
   $service_name               = $rabbitmq::service_name
@@ -100,7 +101,7 @@ class rabbitmq::config {
     if $erlang_cookie == undef {
       fail('You must set the $erlang_cookie value in order to configure clustering.')
     } else {
-      rabbitmq_erlang_cookie { '/var/lib/rabbitmq/.erlang.cookie':
+      rabbitmq_erlang_cookie { "${rabbitmq_home}/.erlang.cookie":
         content      => $erlang_cookie,
         force        => $wipe_db_on_cookie_change,
         service_name => $service_name,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,8 @@ class rabbitmq::config {
   $management_port            = $rabbitmq::management_port
   $node_ip_address            = $rabbitmq::node_ip_address
   $plugin_dir                 = $rabbitmq::plugin_dir
+  $rabbitmq_user              = $rabbitmq::rabbitmq_user
+  $rabbitmq_group             = $rabbitmq::rabbitmq_group
   $rabbitmq_home              = $rabbitmq::rabbitmq_home
   $port                       = $rabbitmq::port
   $tcp_keepalive              = $rabbitmq::tcp_keepalive
@@ -102,11 +104,14 @@ class rabbitmq::config {
       fail('You must set the $erlang_cookie value in order to configure clustering.')
     } else {
       rabbitmq_erlang_cookie { "${rabbitmq_home}/.erlang.cookie":
-        content      => $erlang_cookie,
-        force        => $wipe_db_on_cookie_change,
-        service_name => $service_name,
-        before       => File['rabbitmq.config'],
-        notify       => Class['rabbitmq::service'],
+        content        => $erlang_cookie,
+        force          => $wipe_db_on_cookie_change,
+        rabbitmq_user  => $rabbitmq_user,
+        rabbitmq_group => $rabbitmq_group,
+        rabbitmq_home  => $rabbitmq_home,
+        service_name   => $service_name,
+        before         => File['rabbitmq.config'],
+        notify         => Class['rabbitmq::service'],
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,9 @@ class rabbitmq(
   $repos_ensure               = $rabbitmq::params::repos_ensure,
   $manage_repos               = $rabbitmq::params::manage_repos,
   $plugin_dir                 = $rabbitmq::params::plugin_dir,
+  $rabbitmq_user              = $rabbitmq::params::rabbitmq_user,
+  $rabbitmq_group             = $rabbitmq::params::rabbitmq_group,
+  $rabbitmq_home              = $rabbitmq::params::rabbitmq_home,
   $port                       = $rabbitmq::params::port,
   $tcp_keepalive              = $rabbitmq::params::tcp_keepalive,
   $service_ensure             = $rabbitmq::params::service_ensure,
@@ -183,6 +186,7 @@ class rabbitmq(
     }
 
     Class['::rabbitmq::service'] -> Class['::rabbitmq::install::rabbitmqadmin']
+    Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
   }
 
   if $stomp_ensure {
@@ -212,6 +216,5 @@ class rabbitmq(
 
   # Make sure the various providers have their requirements in place.
   Class['::rabbitmq::install'] -> Rabbitmq_plugin<| |>
-  Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
 
 }

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -13,7 +13,7 @@ class rabbitmq::install::rabbitmqadmin {
   $protocol = $rabbitmq::ssl ? { false => 'http', default => 'https' }
 
   staging::file { 'rabbitmqadmin':
-    target      => '/var/lib/rabbitmq/rabbitmqadmin',
+    target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     source      => "${protocol}://${default_user}:${default_pass}@localhost:${management_port}/cli/rabbitmqadmin",
     curl_option => '-k --noproxy localhost --retry 30 --retry-delay 6',
     timeout     => '180',
@@ -26,8 +26,8 @@ class rabbitmq::install::rabbitmqadmin {
 
   file { '/usr/local/bin/rabbitmqadmin':
     owner   => 'root',
-    group   => 'root',
-    source  => '/var/lib/rabbitmq/rabbitmqadmin',
+    group   => '0',
+    source  => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     mode    => '0755',
     require => Staging::File['rabbitmqadmin'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,10 @@ class rabbitmq::params {
       $package_name     = 'rabbitmq'
       $service_name     = 'rabbitmq'
       $version          = '3.1.3-1'
+      $rabbitmq_user    = 'rabbitmq'
+      $rabbitmq_group   = 'rabbitmq'
+      $rabbitmq_home    = '/var/lib/rabbitmq'
+      $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
     }
     'Debian': {
       $package_ensure   = 'installed'
@@ -17,6 +21,20 @@ class rabbitmq::params {
       $service_name     = 'rabbitmq-server'
       $package_provider = 'apt'
       $version          = '3.1.5'
+      $rabbitmq_user    = 'rabbitmq'
+      $rabbitmq_group   = 'rabbitmq'
+      $rabbitmq_home    = '/var/lib/rabbitmq'
+      $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
+    }
+    'OpenBSD': {
+      $package_ensure   = 'installed'
+      $package_name     = 'rabbitmq'
+      $service_name     = 'rabbitmq'
+      $version          = '3.4.2'
+      $rabbitmq_user    = '_rabbitmq'
+      $rabbitmq_group   = '_rabbitmq'
+      $rabbitmq_home    = '/var/rabbitmq'
+      $plugin_dir       = '/usr/local/lib/rabbitmq/plugins'
     }
     'RedHat': {
       $package_ensure   = 'installed'
@@ -24,6 +42,10 @@ class rabbitmq::params {
       $service_name     = 'rabbitmq-server'
       $package_provider = 'rpm'
       $version          = '3.1.5-1'
+      $rabbitmq_user    = 'rabbitmq'
+      $rabbitmq_group   = 'rabbitmq'
+      $rabbitmq_home    = '/var/lib/rabbitmq'
+      $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
     }
     'SUSE': {
       $package_ensure   = 'installed'
@@ -31,6 +53,10 @@ class rabbitmq::params {
       $service_name     = 'rabbitmq-server'
       $package_provider = 'zypper'
       $version          = '3.1.5-1'
+      $rabbitmq_user    = 'rabbitmq'
+      $rabbitmq_group   = 'rabbitmq'
+      $rabbitmq_home    = '/var/lib/rabbitmq'
+      $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
     }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
@@ -61,7 +87,6 @@ class rabbitmq::params {
   $erlang_cookie              = undef
   $interface                  = 'UNSET'
   $node_ip_address            = 'UNSET'
-  $plugin_dir                 = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
   $port                       = '5672'
   $tcp_keepalive              = false
   $ssl                        = false

--- a/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
@@ -14,13 +14,10 @@ describe provider_class do
   end
 
   it 'should return instances' do
-    provider_class.expects(:rabbitmqctl).with('list_vhosts').returns <<-EOT
-Listing vhosts ...
+    provider_class.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
 /
-...done.
 EOT
-    provider_class.expects(:rabbitmqctl).with('list_exchanges', '-p', '/', 'name', 'type').returns <<-EOT
-Listing exchanges ...
+    provider_class.expects(:rabbitmqctl).with('-q', 'list_exchanges', '-p', '/', 'name', 'type').returns <<-EOT
         direct
 	amq.direct      direct
 	amq.fanout      fanout
@@ -29,7 +26,6 @@ Listing exchanges ...
 	amq.rabbitmq.log        topic
 	amq.rabbitmq.trace      topic
 	amq.topic       topic
-	...done.
 EOT
     instances = provider_class.instances
     instances.size.should == 8


### PR DESCRIPTION
This is a two commits pull request, the majority is in order to add support for OpenBSD.

The other smaller part, that I ran into after getting the module to work, is to fix lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb.

Both explained below.

To support OpenBSD, in the manifests/params.pp, add some more variables, esp. for the rabbitmq_home directory, the rabbitmq system user and group, and additionally make the $plugin_dir OS/Distribution dependent. Then use the new variables throughout the other manifests, where the hardcoded versions were used before.
Further in manifests/init.pp, the dependency of Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |> is moved up into the if $admin_enable part, since it will throw an error, if rabbitmq admin is not enabled.
In manifests/install/rabbitmqadmin.pp, the group of the rabbitmqadmin file was changed from 'root' -> '0'. 
On *BSD, there is not group root, the equivalent group with GID 0 is called wheel.
Other option would be to have the group name added as an OS dependent parameter.

The problem with the rabbitmq_exchange was, that on successive runs, it always re-created the configured exchanges every time. The parse_command method in the provider was flawed. The provider was restructured, to use rabbitmqctl -q, and with that, the whole parse_command method could and was dropped.
The spec testing for that was updated to reflect the changes.

This development was done on a current OpenBSD 5.7-beta, using rabbitmq-3.4.2.

comments, feedback, or if you like just merge it, welcome ;)

thanks,
Sebastian