### PR TITLE
Fix for incorrect apt repo key value.

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,7 +6,7 @@ class rabbitmq::repo::apt(
   $release     = 'testing',
   $repos       = 'main',
   $include_src = false,
-  $key         = 'F7B8CEA6056E8E56',
+  $key         = '056E8E56',
   $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
   $key_content = undef,
   ) {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -815,7 +815,7 @@ describe 'rabbitmq' do
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F7B8CEA6056E8E56'
+          'key'         => '056E8E56'
         ) }
       end
     end
@@ -829,7 +829,7 @@ describe 'rabbitmq' do
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F7B8CEA6056E8E56'
+          'key'         => '056E8E56'
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
The key 'F7B8CEA6056E8E56' is incorrect which results in the module adding this key on every run. Correct key is: '056E8E56' as taken from http://www.rabbitmq.com/signatures.html