### PR TITLE
Remove values validation in policy definition

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -64,13 +64,8 @@ Puppet::Type.newtype(:rabbitmq_policy) do
   end
 
   def validate_definition(definition)
-    unless [Hash].include?(definition.class)
+    unless definition.is_a?(Hash)
       raise ArgumentError, "Invalid definition"
-    end
-    definition.each do |k,v|
-      unless [String].include?(v.class)
-        raise ArgumentError, "Invalid definition"
-      end
     end
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -5,10 +5,11 @@ describe Puppet::Type.type(:rabbitmq_policy) do
 
   before do
     @policy = Puppet::Type.type(:rabbitmq_policy).new(
-      :name       => 'ha-all@/',
+      :name       => 'ha-exactly@/',
       :pattern    => '.*',
       :definition => {
-        'ha-mode' => 'all'
+        'ha-mode' => 'exactly',
+        'ha-params' => 2,
       })
   end
 
@@ -67,10 +68,6 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should not accept invalid hash for definition' do
     expect {
       @policy[:definition] = 'ha-mode'
-    }.to raise_error(Puppet::Error, /Invalid definition/)
-
-    expect {
-      @policy[:definition] = {'ha-mode' => ['a', 'b']}
     }.to raise_error(Puppet::Error, /Invalid definition/)
   end
 


### PR DESCRIPTION
This fixes https://tickets.puppetlabs.com/browse/MODULES-1807 because something like ha-params should be an integer, not a string.