### PR TITLE
Fix file limit for future parser

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class rabbitmq(
   validate_re($stomp_port, '\d+')
   validate_bool($wipe_db_on_cookie_change)
   validate_bool($tcp_keepalive)
-  validate_re($file_limit, '\d+')
+  validate_re($file_limit, '^(\d+|-1|unlimited|infinity)$')
   # Validate service parameters.
   validate_re($service_ensure, '^(running|stopped)$')
   validate_bool($service_manage)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,5 +116,5 @@ class rabbitmq::params {
   $environment_variables      = {}
   $config_variables           = {}
   $config_kernel_variables    = {}
-  $file_limit                 = 16384
+  $file_limit                 = '16384'
 }


### PR DESCRIPTION
The validate_re() function takes a string as first argument, so passing in an integer is invalid.