### PR TITLE
Removed apt module dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,6 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=2.0.0 <5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">=1.0.0 <2.0.0" },
     { "name": "nanliu/staging", "version_requirement": ">=0.3.1 <2.0.0" }
   ]
 }


### PR DESCRIPTION
Apt is not needed on other systems like Red Hat familly of Oses