### PR TITLE
MODULES-1856 - Fix to allow bindings and queues to be created on non-def...

### DIFF
--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -90,6 +90,8 @@ Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin) do
       vhost_opt,
       "--user=#{resource[:user]}",
       "--password=#{resource[:password]}",
+      '-c',
+      '/etc/rabbitmq/rabbitmqadmin.conf',
       "source=#{name}",
       "destination=#{destination}",
       "arguments=#{arguments.to_json}",
@@ -103,7 +105,7 @@ Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin) do
     vhost_opt = should_vhost ? "--vhost=#{should_vhost}" : ''
     name = resource[:name].split('@').first
     destination = resource[:name].split('@')[1]
-    rabbitmqadmin('delete', 'binding', vhost_opt, "--user=#{resource[:user]}", "--password=#{resource[:password]}", "source=#{name}", "destination_type=#{resource[:destination_type]}", "destination=#{destination}")
+    rabbitmqadmin('delete', 'binding', vhost_opt, "--user=#{resource[:user]}", "--password=#{resource[:password]}", '-c', '/etc/rabbitmq/rabbitmqadmin.conf', "source=#{name}", "destination_type=#{resource[:destination_type]}", "destination=#{destination}")
     @property_hash[:ensure] = :absent
   end
 

--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -87,6 +87,8 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
       vhost_opt,
       "--user=#{resource[:user]}",
       "--password=#{resource[:password]}",
+      '-c',
+      '/etc/rabbitmq/rabbitmqadmin.conf',
       "name=#{name}",
       "durable=#{resource[:durable]}",
       "auto_delete=#{resource[:auto_delete]}",
@@ -98,7 +100,7 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
   def destroy
     vhost_opt = should_vhost ? "--vhost=#{should_vhost}" : ''
     name = resource[:name].rpartition('@').first
-    rabbitmqadmin('delete', 'queue', vhost_opt, "--user=#{resource[:user]}", "--password=#{resource[:password]}", "name=#{name}")
+    rabbitmqadmin('delete', 'queue', vhost_opt, "--user=#{resource[:user]}", "--password=#{resource[:password]}", '-c', '/etc/rabbitmq/rabbitmqadmin.conf', "name=#{name}")
     @property_hash[:ensure] = :absent
   end
 

--- a/spec/acceptance/queue_spec.rb
+++ b/spec/acceptance/queue_spec.rb
@@ -1,0 +1,157 @@
+require 'spec_helper_acceptance'
+
+describe 'rabbitmq binding:' do
+
+
+  context "create binding and queue resources when rabbit using default management port" do
+    it 'should run successfully' do
+      pp = <<-EOS
+      if $::osfamily == 'RedHat' {
+        class { 'erlang': epel_enable => true }
+        Class['erlang'] -> Class['::rabbitmq']
+      }
+      class { '::rabbitmq':
+        service_manage    => true,
+        port              => '5672',
+        delete_guest_user => true,
+        admin_enable      => true,
+      } ->
+
+      rabbitmq_user { 'dan':
+        admin    => true,
+        password => 'bar',
+        tags     => ['monitoring', 'tag1'],
+      } ->
+      
+      rabbitmq_user_permissions { 'dan@host1':
+        configure_permission => '.*',
+        read_permission      => '.*',
+        write_permission     => '.*',
+      }
+
+      rabbitmq_vhost { 'host1':
+        ensure => present,
+      } ->
+
+      rabbitmq_exchange { 'exchange1@host1':
+        user     => 'dan',
+        password => 'bar',
+        type     => 'topic',
+        ensure   => present,
+      } ->
+
+      rabbitmq_queue { 'queue1@host1':
+        user        => 'dan',
+        password    => 'bar',
+        durable     => true,
+        auto_delete => false,
+        ensure      => present,
+      } ->
+
+      rabbitmq_binding { 'exchange1@queue1@host1':
+        user             => 'dan',
+        password         => 'bar',
+        destination_type => 'queue',
+        routing_key      => '#',
+        ensure           => present,
+      }
+      
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    it 'should have the binding' do
+      shell('rabbitmqctl list_bindings -q -p host1') do |r|
+        expect(r.stdout).to match(/exchange1\sexchange\squeue1\squeue\s#/)
+        expect(r.exit_code).to be_zero
+      end
+    end
+    
+    it 'should have the queue' do
+      shell('rabbitmqctl list_queues -q -p host1') do |r|
+        expect(r.stdout).to match(/queue1/)
+        expect(r.exit_code).to be_zero
+      end
+    end
+
+  end
+  
+  context "create binding and queue resources when rabbit using a non-default management port" do
+    it 'should run successfully' do
+      pp = <<-EOS
+      if $::osfamily == 'RedHat' {
+        class { 'erlang': epel_enable => true }
+        Class['erlang'] -> Class['::rabbitmq']
+      }
+      class { '::rabbitmq':
+        service_manage    => true,
+        port              => '5672',
+        management_port   => '11111',
+        delete_guest_user => true,
+        admin_enable      => true,
+      } ->
+
+      rabbitmq_user { 'dan':
+        admin    => true,
+        password => 'bar',
+        tags     => ['monitoring', 'tag1'],
+      } ->
+      
+      rabbitmq_user_permissions { 'dan@host2':
+        configure_permission => '.*',
+        read_permission      => '.*',
+        write_permission     => '.*',
+      }
+
+      rabbitmq_vhost { 'host2':
+        ensure => present,
+      } ->
+
+      rabbitmq_exchange { 'exchange2@host2':
+        user     => 'dan',
+        password => 'bar',
+        type     => 'topic',
+        ensure   => present,
+      } ->
+
+      rabbitmq_queue { 'queue2@host2':
+        user        => 'dan',
+        password    => 'bar',
+        durable     => true,
+        auto_delete => false,
+        ensure      => present,
+      } ->
+
+      rabbitmq_binding { 'exchange2@queue2@host2':
+        user             => 'dan',
+        password         => 'bar',
+        destination_type => 'queue',
+        routing_key      => '#',
+        ensure           => present,
+      }
+     
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    it 'should have the binding' do
+      shell('rabbitmqctl list_bindings -q -p host2') do |r|
+        expect(r.stdout).to match(/exchange2\sexchange\squeue2\squeue\s#/)
+        expect(r.exit_code).to be_zero
+      end
+    end
+    
+    it 'should have the queue' do
+      shell('rabbitmqctl list_queues -q -p host2') do |r|
+        expect(r.stdout).to match(/queue2/)
+        expect(r.exit_code).to be_zero
+      end
+    end
+
+  end
+  
+end

--- a/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
@@ -28,12 +28,12 @@ EOT
   end
   
   it 'should call rabbitmqadmin to create' do
-    @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=guest', '--password=guest', 'source=source', 'destination=target', 'arguments={}', 'routing_key=blablub', 'destination_type=queue')
+    @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination=target', 'arguments={}', 'routing_key=blablub', 'destination_type=queue')
     @provider.create
   end
 
   it 'should call rabbitmqadmin to destroy' do
-    @provider.expects(:rabbitmqadmin).with('delete', 'binding', '--vhost=/', '--user=guest', '--password=guest', 'source=source', 'destination_type=queue', 'destination=target')
+    @provider.expects(:rabbitmqadmin).with('delete', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination_type=queue', 'destination=target')
     @provider.destroy
   end
 
@@ -52,7 +52,7 @@ EOT
     end
 
     it 'should call rabbitmqadmin to create' do
-      @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=colin', '--password=secret', 'source=source', 'destination=test2', 'arguments={}', 'routing_key=blablubd', 'destination_type=queue')
+      @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=colin', '--password=secret', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination=test2', 'arguments={}', 'routing_key=blablubd', 'destination_type=queue')
       @provider.create
     end
   end

--- a/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
@@ -29,12 +29,12 @@ EOT
   end
 
   it 'should call rabbitmqadmin to create' do
-    @provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=guest', '--password=guest', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
+    @provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
     @provider.create
   end
 
   it 'should call rabbitmqadmin to destroy' do
-    @provider.expects(:rabbitmqadmin).with('delete', 'queue', '--vhost=/', '--user=guest', '--password=guest', 'name=test')
+    @provider.expects(:rabbitmqadmin).with('delete', 'queue', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test')
     @provider.destroy
   end
 
@@ -53,7 +53,7 @@ EOT
     end
 
     it 'should call rabbitmqadmin to create' do
-      @provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=colin', '--password=secret', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
+      @provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=colin', '--password=secret', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
       @provider.create
     end
   end


### PR DESCRIPTION
MODULES-1856 - Fix to allow bindings and queues to be created
when non-default management port is being used by rabbitmq.

Without this fix the rabbitmq_binding & rabbitmq_queue providers are unable to work when
rabbitmq is running on a non-default management port. This fix fixes the problem by passing in
the /etc/rabbitmq/rabbitmqadmin.conf to the call to rabbitmqadmin so that the port can be read from the conf file.