### PR TITLE
Add new line in ssl options

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -58,6 +58,7 @@
       {port, <%= @ssl_management_port %>},
       {ssl, true},
       {ssl_opts, [<%- if @ssl_cacert != 'UNSET' -%>{cacertfile, "<%= @ssl_cacert %>"},<%- end -%>
+
                   {certfile, "<%= @ssl_cert %>"},
                   {keyfile, "<%= @ssl_key %>"}
                    <%- if @ssl_versions -%>


### PR DESCRIPTION
Rabbitmq does not start the management service properly (the symptom on my system was not reading the ssl-private cert) if this extra carriage return is not in the template, which causes extra spacing for ssl options between ssl_cacert and ssl_cert.
