### PR TITLE
set_policy: convert known parameters to integers

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -43,6 +43,9 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     validate do |value|
       resource.validate_definition(value)
     end
+    munge do |value|
+      resource.munge_definition(value)
+    end
   end
 
   newproperty(:priority) do
@@ -72,21 +75,27 @@ Puppet::Type.newtype(:rabbitmq_policy) do
         raise ArgumentError, "Invalid definition"
       end
     end
-    # If ha-mode is 'exactly', convert ha-params to integer
     if definition['ha-mode'] == 'exactly'
       ha_params = definition['ha-params']
       unless ha_params.to_i.to_s == ha_params
         raise ArgumentError, "Invalid ha-params '#{ha_params}' for ha-mode 'exactly'"
       end
-      definition['ha-params'] = ha_params.to_i
     end
-
     if definition.key? 'expires'
       expires_val = definition['expires']
       unless expires_val.to_i.to_s == expires_val
         raise ArgumentError, "Invalid expires value '#{expires_val}'"
       end
-      definition['expires'] = expires_val.to_i
     end
+  end
+
+  def munge_definition(definition)
+    if definition['ha-mode'] == 'exactly'
+      definition['ha-params'] = definition['ha-params'].to_i
+    end
+    if definition.key? 'expires'
+      definition['expires'] = definition['expires'].to_i
+    end
+    definition
   end
 end

--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -72,5 +72,21 @@ Puppet::Type.newtype(:rabbitmq_policy) do
         raise ArgumentError, "Invalid definition"
       end
     end
+    # If ha-mode is 'exactly', convert ha-params to integer
+    if definition['ha-mode'] == 'exactly'
+      ha_params = definition['ha-params']
+      unless ha_params.to_i.to_s == ha_params
+        raise ArgumentError, "Invalid ha-params '#{ha_params}' for ha-mode 'exactly'"
+      end
+      definition['ha-params'] = ha_params.to_i
+    end
+
+    if definition.key? 'expires'
+      expires_val = definition['expires']
+      unless expires_val.to_i.to_s == expires_val
+        raise ArgumentError, "Invalid expires value '#{expires_val}'"
+      end
+      definition['expires'] = expires_val.to_i
+    end
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -88,4 +88,30 @@ describe Puppet::Type.type(:rabbitmq_policy) do
       }.to raise_error(Puppet::Error, /Invalid value/)
     end
   end
+
+  it 'should accept and convert ha-params for ha-mode exactly' do
+    definition = {'ha-mode' => 'exactly', 'ha-params' => '2'}
+    @policy[:definition] = definition
+    @policy[:definition]['ha-params'].should be_a(Fixnum)
+  end
+
+  it 'should not accept non-numeric ha-params for ha-mode exactly' do
+    definition = {'ha-mode' => 'exactly', 'ha-params' => 'nonnumeric'}
+    expect {
+      @policy[:definition] = definition
+    }.to raise_error(Puppet::Error, /Invalid ha-params.*nonnumeric.*exactly/)
+  end
+
+  it 'should accept and convert the expires value' do
+    definition = {'expires' => '1800000'}
+    @policy[:definition] = definition
+    @policy[:definition]['expires'].should be_a(Fixnum)
+  end
+
+  it 'should not accept non-numeric expires value' do
+    definition = {'expires' => 'future'}
+    expect {
+      @policy[:definition] = definition
+    }.to raise_error(Puppet::Error, /Invalid expires value.*future/)
+  end
 end

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -93,6 +93,7 @@ describe Puppet::Type.type(:rabbitmq_policy) do
     definition = {'ha-mode' => 'exactly', 'ha-params' => '2'}
     @policy[:definition] = definition
     @policy[:definition]['ha-params'].should be_a(Fixnum)
+    @policy[:definition]['ha-params'].should == 2
   end
 
   it 'should not accept non-numeric ha-params for ha-mode exactly' do
@@ -106,6 +107,7 @@ describe Puppet::Type.type(:rabbitmq_policy) do
     definition = {'expires' => '1800000'}
     @policy[:definition] = definition
     @policy[:definition]['expires'].should be_a(Fixnum)
+    @policy[:definition]['expires'].should == 1800000
   end
 
   it 'should not accept non-numeric expires value' do


### PR DESCRIPTION
When using set_policy to define the 'expires' policy, or setting 'ha-params'
when using 'ha-mode' 'exactly', the rabbitmqctl provider passes a stringified
numeric value to the `rabbitmqctl set_policy' invocation. In turn, this one
chokes on the values and throws the following error:

err: ...
set_policy -p vhost --priority 0 --apply-to queues expire_queues ^rpc_.* {"expires":"1800000"}' returned 2:
Setting policy "expire_queues" for pattern "^rtcp_.*" to "{\"expires\":\"1800000\"}" with priority "0"
...
<<"1800000">> is not a valid queue expiry

This is with puppet 2.7.

I'm not 100% sure why this happens - it seems the a hash is passed all-strings
down to the type/provider in 2.7? Even if in the manifest file, a numeric
value is used. Hum?

 82     rabbitmq_policy { 'expire_queues@vhost':
 83         pattern => '^rpc_.*',
 84         applyto => 'queues',
 85         definition => {
 86             'expires' => 1800000,
 87         }
 88     }

As a work-around, this commit adds two special cases to explicity convert
the 'ha-params' field in case of ha-mode 'exactly' as well as converting
the 'expires' setting when provided.