### PR TITLE
Don't create rabbitmqadmin.conf if disabled

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -78,14 +78,16 @@ class rabbitmq::config {
     notify  => Class['rabbitmq::service'],
   }
 
-  file { 'rabbitmqadmin.conf':
-    ensure  => file,
-    path    => '/etc/rabbitmq/rabbitmqadmin.conf',
-    content => template('rabbitmq/rabbitmqadmin.conf.erb'),
-    owner   => '0',
-    group   => '0',
-    mode    => '0644',
-    require => File['/etc/rabbitmq'],
+  if $admin_enable {
+    file { 'rabbitmqadmin.conf':
+      ensure  => file,
+      path    => '/etc/rabbitmq/rabbitmqadmin.conf',
+      content => template('rabbitmq/rabbitmqadmin.conf.erb'),
+      owner   => '0',
+      group   => '0',
+      mode    => '0644',
+      require => File['/etc/rabbitmq'],
+    }
   }
 
   if $config_cluster {


### PR DESCRIPTION
If the admin service isn't enabled then we shouldn't create the config
file.

This caused an issue for us because any changes to any resources in rabbitmq::config will cause rabbit to be restarted.  We had intentionally disabled admin when moving to a newer version of the module, because we were trying to avoid restarting rabbit at the time.  Due to this file being created, we had rabbit restarts due to a feature we had explicitly disabled.