### PR TITLE
Fix check_password function and use the standard rabbitmq api call instead

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -45,8 +45,8 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl, :parent => Puppet::Provi
 
 
   def check_password
-    response = rabbitmqctl('eval', 'rabbit_auth_backend_internal:check_user_login(<<"' + resource[:name] + '">>, [{password, <<"' + resource[:password] +'">>}]).')
-    if response.include? 'invalid credentials'
+    response = rabbitmqctl('eval', 'rabbit_access_control:check_user_pass_login(list_to_binary("' + resource[:name] + '"), list_to_binary("' + resource[:password] +'")).')
+    if response.include? 'refused'
         false
     else
         true


### PR DESCRIPTION
Old one was failing with:

Error: Execution of '/usr/sbin/rabbitmqctl eval rabbit_auth_backend_internal:check_user_login(<<"root">>, [{password, <<"pass">>}]).' returned 2: Error: {undef,
           [{rabbit_auth_backend_internal,check_user_login,
                [<<"root">>,[{password,<<"pass">>}]],
                []},
            {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,569}]},
            {rpc,'-handle_call_call/6-fun-0-',5,
                [{file,"rpc.erl"},{line,205}]}]}

rabbitmq-server                     3.5.0-1 