### PR TITLE
Add support for SSL Cipher lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,14 @@ Choose which SSL versions to enable. Example: `['tlsv1.2', 'tlsv1.1']`.
 
 Note that it is recommended to disable `sslv3` and `tlsv1` to prevent against POODLE and BEAST attacks. Please see the [RabbitMQ SSL](https://www.rabbitmq.com/ssl.html) documentation for more information.
 
+####`ssl_ciphers`
+
+Support only a given list of SSL ciphers. Example: `['dhe_rsa,aes_256_cbc,sha','dhe_dss,aes_256_cbc,sha','ecdhe_rsa,aes_256_cbc,sha']`.
+
+Supported ciphers in your install can be listed with:
+ rabbitmqctl eval 'ssl:cipher_suites().'
+Functionality can be tested with cipherscan or similar tool: https://github.com/jvehent/cipherscan.git
+
 ####`stomp_port`
 
 The port to use for Stomp.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -37,6 +37,7 @@ class rabbitmq::config {
   $ssl_verify                 = $rabbitmq::ssl_verify
   $ssl_fail_if_no_peer_cert   = $rabbitmq::ssl_fail_if_no_peer_cert
   $ssl_versions               = $rabbitmq::ssl_versions
+  $ssl_ciphers                = $rabbitmq::ssl_ciphers
   $stomp_port                 = $rabbitmq::stomp_port
   $ldap_auth                  = $rabbitmq::ldap_auth
   $ldap_server                = $rabbitmq::ldap_server

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class rabbitmq(
   $ssl_verify                 = $rabbitmq::params::ssl_verify,
   $ssl_fail_if_no_peer_cert   = $rabbitmq::params::ssl_fail_if_no_peer_cert,
   $ssl_versions               = $rabbitmq::params::ssl_versions,
+  $ssl_ciphers                = $rabbitmq::params::ssl_ciphers,
   $stomp_ensure               = $rabbitmq::params::stomp_ensure,
   $ldap_auth                  = $rabbitmq::params::ldap_auth,
   $ldap_server                = $rabbitmq::params::ldap_server,
@@ -112,6 +113,7 @@ class rabbitmq(
   validate_string($ssl_cacert)
   validate_string($ssl_cert)
   validate_string($ssl_key)
+  validate_array($ssl_ciphers)
   if ! is_integer($ssl_port) {
     validate_re($ssl_port, '\d+')
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -101,6 +101,7 @@ class rabbitmq::params {
   $ssl_verify                 = 'verify_none'
   $ssl_fail_if_no_peer_cert   = false
   $ssl_versions               = undef
+  $ssl_ciphers                = []
   $stomp_ensure               = false
   $ldap_auth                  = false
   $ldap_server                = 'ldap'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -641,6 +641,21 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'ssl options with ssl ciphers' do
+        let(:params) {
+          { :ssl => true,
+            :ssl_port => 3141,
+            :ssl_cacert => '/path/to/cacert',
+            :ssl_cert => '/path/to/cert',
+            :ssl_key => '/path/to/key',
+            :ssl_ciphers => ['ecdhe_rsa,aes_256_cbc,sha', 'dhe_rsa,aes_256_cbc,sha']
+        } }
+
+        it 'should set ssl ciphers to specified values' do
+          should contain_file('rabbitmq.config').with_content(%r{ciphers,\[[[:space:]]+{dhe_rsa,aes_256_cbc,sha},[[:space:]]+{ecdhe_rsa,aes_256_cbc,sha}[[:space:]]+\]})
+        end
+      end
+
       describe 'ssl admin options with specific ssl versions' do
         let(:params) {
           { :ssl => true,

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -37,6 +37,11 @@
                    <%- if @ssl_versions -%>
                    ,{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}
                    <%- end -%>
+                   <%- if @ssl_ciphers and @ssl_ciphers.size > 0 -%>
+                   ,{ciphers,[
+                     <%= @ssl_ciphers.sort.map{|k| "{#{k}}"}.join(",\n                     ") %>
+                   ]}
+                   <%- end -%>
                   ]},
 <%- end -%>
 <% if @config_variables -%>
@@ -62,7 +67,13 @@
                   {keyfile, "<%= @ssl_key %>"}
                    <%- if @ssl_versions -%>
                      ,{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}
-                   <% end -%>]}
+                   <%- end -%>
+                  <%- if @ssl_ciphers and @ssl_ciphers.size > 0 -%>
+                  ,{ciphers,[
+                      <%= @ssl_ciphers.sort.map{|k| "{#{k}}"}.join(",\n                      ") %>
+                  ]}
+                  <%- end -%>
+                 ]}
 <%- else -%>
       {port, <%= @management_port %>}
 <%- end -%>


### PR DESCRIPTION
This patch adds optional array parameter 'ssl_ciphers' which go into rabbitmq's config if SSL is enabled and limit the ciphers to the specified list.

Documentation is erlang as these parameters are passed through: http://www.erlang.org/doc/man/ssl.html
Supported ciphers can be listed with: rabbitmqctl eval 'ssl:cipher_suites().'
Functionality can be tested with something like Cipherscan: https://github.com/jvehent/cipherscan.git
