### PR TITLE
Remove duplicate $ssl_interface

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,7 +29,6 @@ class rabbitmq::config {
   $ssl_only                   = $rabbitmq::ssl_only
   $ssl_cacert                 = $rabbitmq::ssl_cacert
   $ssl_cert                   = $rabbitmq::ssl_cert
-  $ssl_interface              = $rabbitmq::ssl_interface
   $ssl_key                    = $rabbitmq::ssl_key
   $ssl_port                   = $rabbitmq::ssl_port
   $ssl_interface              = $rabbitmq::ssl_interface


### PR DESCRIPTION
This was added twice in two separate pull requests and
causes the following error:

Error: Cannot reassign variable ssl_interface at /etc/puppet/modules/rabbitmq/manifests/config.pp:35