### PR TITLE
fix to allow specifying either key_content or package_gpg_key

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
+    "apt": 
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      branch: "1.8.x"
     "staging": "git://github.com/nanliu/puppet-staging.git"
     erlang:
       repo: "https://github.com/garethr/garethr-erlang.git"

--- a/README.md
+++ b/README.md
@@ -63,8 +63,15 @@ class { '::rabbitmq':
 Or such as offline installation from intranet or local mirrors:
 
 ```puppet
+# using key_content to specify key
 class { '::rabbitmq':
    key_content      => template('openstack/rabbit.pub.key'),
+   package_gpg_key  => false,
+}
+
+# specifying a file containing key material
+class { '::rabbitmq':
+   key_content      => undef,
    package_gpg_key  => '/tmp/rabbit.pub.key',
 }
 ```

--- a/README.md
+++ b/README.md
@@ -581,6 +581,10 @@ For Debian systems:
       ensure => 'latest',
     }
 
+This module also depends on the excellent nanliu/staging module on the Forge:
+
+    puppet module install nanliu-staging
+
 ### Downgrade Issues
 
 Be advised that there were configuration file syntax and other changes made between RabbitMQ

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,7 +6,7 @@ class rabbitmq::repo::apt(
   $release     = 'testing',
   $repos       = 'main',
   $include_src = false,
-  $key         = 'F7B8CEA6056E8E56',
+  $key         = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
   $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
   $key_content = undef,
   ) {

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -20,6 +20,19 @@ class rabbitmq::repo::apt(
     default => 'present',
   }
 
+  # if key_content is defined then key_source must be set to undef (not false)
+  # or vice versa, the apt_key provider will translate false as a string
+  if ($key_content)
+  {
+    $aux_key_content = $key_content
+    $aux_key_source = undef
+  }
+  else
+  {
+    $aux_key_content = undef
+    $aux_key_source = $key_source
+  }
+
   apt::source { 'rabbitmq':
     ensure      => $ensure_source,
     location    => $location,
@@ -27,8 +40,8 @@ class rabbitmq::repo::apt(
     repos       => $repos,
     include_src => $include_src,
     key         => $key,
-    key_source  => $key_source,
-    key_content => $key_content,
+    key_source  => $aux_key_source,
+    key_content => $aux_key_content,
   }
 
   if $pin != '' {

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.0.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
     {"name":"nanliu/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1056,7 +1056,7 @@ rabbitmq hard nofile 1234
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F7B8CEA6056E8E56'
+          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
         ) }
       end
     end
@@ -1070,7 +1070,7 @@ rabbitmq hard nofile 1234
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F7B8CEA6056E8E56'
+          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -26,7 +26,7 @@ RSpec.configure do |c|
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
       shell('puppet module install puppetlabs-stdlib', { :acceptable_exit_codes => [0,1] })
       if fact('osfamily') == 'Debian'
-        shell('puppet module install puppetlabs-apt', { :acceptable_exit_codes => [0,1] })
+        shell('puppet module install puppetlabs-apt --version 1.8.0 --force', { :acceptable_exit_codes => [0,1] })
       end
       shell('puppet module install nanliu-staging', { :acceptable_exit_codes => [0,1] })
       if fact('osfamily') == 'RedHat'

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -63,6 +63,7 @@
       {port, <%= @ssl_management_port %>},
       {ssl, true},
       {ssl_opts, [<%- if @ssl_cacert != 'UNSET' -%>{cacertfile, "<%= @ssl_cacert %>"},<%- end -%>
+
                   {certfile, "<%= @ssl_cert %>"},
                   {keyfile, "<%= @ssl_key %>"}
                    <%- if @ssl_versions -%>


### PR DESCRIPTION
The example in the README.md is confusing and doesn't work.

1. There is no way to specify $key_content without the apt_key provider complaining (see [here](https://github.com/puppetlabs/puppetlabs-apt/blob/master/lib/puppet/type/apt_key.rb#L22-L29)).

2. Also when specifying the $packaging_gpg_key and setting to a file, you must explicitly set $key_content to undef, otherwise we get stuck in the same issue (this was originally confusing because the example was wrong).

This patch attempts to avoid any confusion and tries to alert the user if there's an invalid combination which will not work with apt_key.