### PR TITLE
Provided full key fingerprint to suppress warning

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,7 +6,7 @@ class rabbitmq::repo::apt(
   $release     = 'testing',
   $repos       = 'main',
   $include_src = false,
-  $key         = 'F7B8CEA6056E8E56',
+  $key         = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
   $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
   $key_content = undef,
   ) {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1056,7 +1056,7 @@ rabbitmq hard nofile 1234
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F7B8CEA6056E8E56'
+          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
         ) }
       end
     end
@@ -1070,7 +1070,7 @@ rabbitmq hard nofile 1234
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F7B8CEA6056E8E56'
+          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
Puppet gives this warning when installing RabbitMQ:

    Warning: /Apt_key[Add key: F7B8CEA6056E8E56 from Apt::Source rabbitmq]: The id should be a full fingerprint (40 characters), see README.

This patch provides the full fingerprint to prevent this warning from showing.