### PR TITLE
add some clarity to README.md

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
+    "apt": 
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      branch: "1.8.x"
     "staging": "git://github.com/nanliu/puppet-staging.git"
     erlang:
       repo: "https://github.com/garethr/garethr-erlang.git"

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ rabbitmq_user { 'dan':
 query all current vhosts: `$ puppet resource rabbitmq_vhost`
 
 ```puppet
-rabbitmq_vhost { 'myhost':
+rabbitmq_vhost { 'myvhost':
   ensure => present,
 }
 ```
@@ -450,7 +450,7 @@ rabbitmq_vhost { 'myhost':
 ### rabbitmq\_exchange
 
 ```puppet
-rabbitmq_exchange { 'myexchange@myhost':
+rabbitmq_exchange { 'myexchange@myvhost':
   user     => 'dan',
   password => 'bar',
   type     => 'topic',
@@ -467,7 +467,7 @@ rabbitmq_exchange { 'myexchange@myhost':
 ### rabbitmq\_queue
 
 ```puppet
-rabbitmq_queue { 'myqueue@myhost':
+rabbitmq_queue { 'myqueue@myvhost':
   user        => 'dan',
   password    => 'bar',
   durable     => true,
@@ -483,7 +483,7 @@ rabbitmq_queue { 'myqueue@myhost':
 ### rabbitmq\_binding
 
 ```puppet
-rabbitmq_binding { 'myexchange@myqueue@myhost':
+rabbitmq_binding { 'myexchange@myqueue@myvhost':
   user             => 'dan',
   password         => 'bar',
   destination_type => 'queue',
@@ -496,7 +496,7 @@ rabbitmq_binding { 'myexchange@myqueue@myhost':
 ### rabbitmq\_user\_permissions
 
 ```puppet
-rabbitmq_user_permissions { 'dan@myhost':
+rabbitmq_user_permissions { 'dan@myvhost':
   configure_permission => '.*',
   read_permission      => '.*',
   write_permission     => '.*',
@@ -506,7 +506,7 @@ rabbitmq_user_permissions { 'dan@myhost':
 ### rabbitmq\_policy
 
 ```puppet
-rabbitmq_policy { 'ha-all@myhost':
+rabbitmq_policy { 'ha-all@myvhost':
   pattern    => '.*',
   priority   => 0,
   applyto    => 'all',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -26,7 +26,7 @@ RSpec.configure do |c|
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
       shell('puppet module install puppetlabs-stdlib', { :acceptable_exit_codes => [0,1] })
       if fact('osfamily') == 'Debian'
-        shell('puppet module install puppetlabs-apt', { :acceptable_exit_codes => [0,1] })
+        shell('puppet module install puppetlabs-apt --version 1.8.0 --force', { :acceptable_exit_codes => [0,1] })
       end
       shell('puppet module install nanliu-staging', { :acceptable_exit_codes => [0,1] })
       if fact('osfamily') == 'RedHat'


### PR DESCRIPTION
I think changing myhost to myvhost in the README.md makes it much clearer because myvhost is self-describing, whereas myhost is ambiguous describing potentially a hostname. This kind of bit me when setting up a ha policy, and would've been much clearer if i saw the distinction "vhost".