### PR TITLE
(MODULES-1987) mnesia dir is not wiped out

### DIFF
--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
   def content=(value)
     if resource[:force] == :true # Danger!
       puppet('resource', 'service', resource[:service_name], 'ensure=stopped')
-      FileUtils.rm_rf(resource[:rabbitmq_home] + File::PATH_SEPARATOR + 'mnesia')
+      FileUtils.rm_rf(resource[:rabbitmq_home] + File::SEPARATOR + 'mnesia')
       File.open(resource[:path], 'w') do |cookie|
         cookie.chmod(0400)
         cookie.write(value)


### PR DESCRIPTION
change separator from “:” to “/“ to generate proper dirname to allow
removal