### PR TITLE
Ensure idempotency between Puppet runs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -120,10 +120,11 @@ class rabbitmq::config {
     'RedHat': {
       if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         file { '/etc/systemd/system/rabbitmq-server.service.d':
-          ensure => directory,
-          owner  => '0',
-          group  => '0',
-          mode   => '0755',
+          ensure                  => directory,
+          owner                   => '0',
+          group                   => '0',
+          mode                    => '0755',
+          selinux_ignore_defaults => true,
         } ->
         file { '/etc/systemd/system/rabbitmq-server.service.d/limits.conf':
           content => template('rabbitmq/rabbitmq-server.service.d/limits.conf'),

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -252,10 +252,11 @@ describe 'rabbitmq' do
     let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => '7' }}
 
     it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d').with(
-      'ensure' => 'directory',
-      'owner'  => '0',
-      'group'  => '0',
-      'mode'   => '0755'
+      'ensure'                  => 'directory',
+      'owner'                   => '0',
+      'group'                   => '0',
+      'mode'                    => '0755',
+      'selinux_ignore_defaults' => true
     ) }
 
     it { should contain_exec('rabbitmq-systemd-reload').with(


### PR DESCRIPTION
Running RHEL 7.1 with 'yum' or 'rpm' provider, puppetlabs-rabbitmq is not
idempotent.
After a second run, puppet tries to change the SElinux context:
<code>/File[/etc/systemd/system/rabbitmq-server.service.d]/seltype: seltype
changed 'rabbitmq_unit_file_t' to 'systemd_unit_file_t'</code>

Since packaging already manages SElinux labels, we should not let Puppet
doing it (default behavior).
This patch aims to set selinux_ignore_defaults to True for the File
resource (/etc/systemd/system/rabbitmq-server.service.d).

Thanks to that patch, Puppet will be indempotent between all runs on
RHEL platforms.