### PR TITLE
Allow to manage Erlang Cookie without config_cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ RabbitMQ Environment Variables in rabbitmq_env.config
 
 The erlang cookie to use for clustering - must be the same between all nodes.
 This value has no default and must be set explicitly if using clustering.
+If you run Pacemaker and you don't want to use RabbitMQ buildin cluster, you can
+set config_cluster to 'False' and set 'erlang_cookie'.
 
 ####`file_limit`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -152,21 +152,18 @@ class rabbitmq::config {
     }
   }
 
-  if $config_cluster {
-
-    if $erlang_cookie == undef {
-      fail('You must set the $erlang_cookie value in order to configure clustering.')
-    } else {
-      rabbitmq_erlang_cookie { "${rabbitmq_home}/.erlang.cookie":
-        content        => $erlang_cookie,
-        force          => $wipe_db_on_cookie_change,
-        rabbitmq_user  => $rabbitmq_user,
-        rabbitmq_group => $rabbitmq_group,
-        rabbitmq_home  => $rabbitmq_home,
-        service_name   => $service_name,
-        before         => File['rabbitmq.config'],
-        notify         => Class['rabbitmq::service'],
-      }
+  if $erlang_cookie == undef and $config_cluster {
+    fail('You must set the $erlang_cookie value in order to configure clustering.')
+  } elsif $erlang_cookie != undef {
+    rabbitmq_erlang_cookie { "${rabbitmq_home}/.erlang.cookie":
+      content        => $erlang_cookie,
+      force          => $wipe_db_on_cookie_change,
+      rabbitmq_user  => $rabbitmq_user,
+      rabbitmq_group => $rabbitmq_group,
+      rabbitmq_home  => $rabbitmq_home,
+      service_name   => $service_name,
+      before         => File['rabbitmq.config'],
+      notify         => Class['rabbitmq::service'],
     }
   }
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -471,6 +471,25 @@ rabbitmq hard nofile 1234
           end
         end
 
+        describe 'with erlang_cookie set but without config_cluster' do
+          let(:params) {{
+            :config_cluster           => false,
+            :erlang_cookie            => 'TESTCOOKIE',
+          }}
+          it 'contains the rabbitmq_erlang_cookie' do
+            should contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
+          end
+        end
+
+        describe 'without erlang_cookie and without config_cluster' do
+          let(:params) {{
+            :config_cluster           => false,
+          }}
+          it 'contains the rabbitmq_erlang_cookie' do
+            should_not contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
+          end
+        end
+
         describe 'and sets appropriate configuration' do
           let(:params) {{
             :config_cluster           => true,


### PR DESCRIPTION
When deploying RabbitMQ in cluster with Pacemaker, we don't want to let
Puppet to manage the cluster so we configure it without clustering options.
Though we need to configure the Erlang Cookie in all RabbitMQ nodes.

This patch aims to:
* allow to configure the cookie without config_cluster boolean at True
* keeps backward compatibility, it will try to install the cookie if the
  config_cluster is at True only (so it won't wail for deployment with
defaults values).
* we try to create the cookie only if it's not set to 'undef'.
* update README about new usage
* add rspec tests to test all possible cases.