### PR TITLE
Added mangement_address parameter to rabbitmq_management configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ Password to set for the `default_user` in rabbitmq.config.
 
 Boolean to decide if we should delete the default guest user.
 
+####`enable_management_ssl`
+
+Boolean to decide if the rabbitmq_management plugin should use ssl. Defaults to `false`.
+
 ####`env_config`
 
 The template file to use for rabbitmq_env.config.
@@ -271,6 +275,10 @@ Boolean, whether or not to manage package repositories.
 ####`management_port`
 
 The port for the RabbitMQ management interface.
+
+####`management_address`
+
+The address for the RabbitMQ management interface. Defaults to bind to all interfaces
 
 ####`node_ip_address`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class rabbitmq::config {
   $env_config_path            = $rabbitmq::env_config_path
   $erlang_cookie              = $rabbitmq::erlang_cookie
   $interface                  = $rabbitmq::interface
+  $management_address         = $rabbitmq::management_address
   $management_port            = $rabbitmq::management_port
   $node_ip_address            = $rabbitmq::node_ip_address
   $plugin_dir                 = $rabbitmq::plugin_dir
@@ -32,6 +33,7 @@ class rabbitmq::config {
   $ssl_key                    = $rabbitmq::ssl_key
   $ssl_port                   = $rabbitmq::ssl_port
   $ssl_interface              = $rabbitmq::ssl_interface
+  $enable_management_ssl      = $rabbitmq::enable_management_ssl
   $ssl_management_port        = $rabbitmq::ssl_management_port
   $ssl_stomp_port             = $rabbitmq::ssl_stomp_port
   $ssl_verify                 = $rabbitmq::ssl_verify

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,10 +10,12 @@ class rabbitmq(
   $default_user               = $rabbitmq::params::default_user,
   $default_pass               = $rabbitmq::params::default_pass,
   $delete_guest_user          = $rabbitmq::params::delete_guest_user,
+  $enable_management_ssl      = $rabbitmq::params::enable_management_ssl,
   $env_config                 = $rabbitmq::params::env_config,
   $env_config_path            = $rabbitmq::params::env_config_path,
   $erlang_cookie              = $rabbitmq::params::erlang_cookie,
   $interface                  = $rabbitmq::params::interface,
+  $management_address         = $rabbitmq::params::management_address,
   $management_port            = $rabbitmq::params::management_port,
   $node_ip_address            = $rabbitmq::params::node_ip_address,
   $package_apt_pin            = $rabbitmq::params::package_apt_pin,
@@ -104,6 +106,9 @@ class rabbitmq(
   if ! is_integer($file_limit) {
     validate_re($file_limit, '^(unlimited|infinity)$', '$file_limit must be an integer, \'unlimited\', or \'infinity\'.')
   }
+  validate_bool($enable_management_ssl)
+  validate_string($management_address)
+
   # Validate service parameters.
   validate_re($service_ensure, '^(running|stopped)$')
   validate_bool($service_manage)
@@ -147,7 +152,11 @@ class rabbitmq(
   if $ssl_versions {
     if $ssl {
       validate_array($ssl_versions)
-    } else {
+    }
+    elsif $enable_management_ssl {
+      validate_array($ssl_versions)
+    }
+    else {
       fail('$ssl_versions requires that $ssl => true')
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,6 +66,7 @@ class rabbitmq::params {
   #install
   $admin_enable               = true
   $management_port            = '15672'
+  $management_address         = 'UNSET'
   $package_apt_pin            = ''
   $package_gpg_key            = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc'
   $repos_ensure               = true
@@ -82,6 +83,7 @@ class rabbitmq::params {
   $default_user               = 'guest'
   $default_pass               = 'guest'
   $delete_guest_user          = false
+  $enable_management_ssl      = false
   $env_config                 = 'rabbitmq/rabbitmq-env.conf.erb'
   $env_config_path            = '/etc/rabbitmq/rabbitmq-env.conf'
   $erlang_cookie              = undef

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -797,7 +797,7 @@ rabbitmq hard nofile 1234
 
       describe 'ssl admin options with specific ssl versions' do
         let(:params) {
-          { :ssl => true,
+          { :enable_management_ssl  => true,
             :ssl_management_port => 5926,
             :ssl_cacert => '/path/to/cacert',
             :ssl_cert => '/path/to/cert',
@@ -820,7 +820,7 @@ rabbitmq hard nofile 1234
 
       describe 'ssl admin options' do
         let(:params) {
-          { :ssl => true,
+          { :enable_management_ssl  => true,
             :ssl_management_port => 3141,
             :ssl_cacert => '/path/to/cacert',
             :ssl_cert => '/path/to/cert',
@@ -841,7 +841,7 @@ rabbitmq hard nofile 1234
 
       describe 'admin without ssl' do
         let(:params) {
-          { :ssl => false,
+          { :enable_management_ssl  => false,
             :management_port => 3141,
             :admin_enable => true
         } }
@@ -855,7 +855,7 @@ rabbitmq hard nofile 1234
 
       describe 'ssl admin options' do
         let(:params) {
-          { :ssl => true,
+          { :enable_management_ssl  => true,
             :ssl_management_port => 3141,
             :ssl_cacert => '/path/to/cacert',
             :ssl_cert => '/path/to/cert',
@@ -876,7 +876,7 @@ rabbitmq hard nofile 1234
 
       describe 'admin without ssl' do
         let(:params) {
-          { :ssl => false,
+          { :enable_management_ssl  => false,
             :management_port => 3141,
             :admin_enable => true
         } }
@@ -886,6 +886,46 @@ rabbitmq hard nofile 1234
             .with_content(/\{rabbitmq_management, \[/) \
             .with_content(/\{listener, \[/) \
             .with_content(/\{port, 3141\}/)
+        end
+      end
+
+      describe 'admin without ssl and specific port set' do
+        let(:params) {
+          { :enable_management_ssl  => false,
+            :management_port => 3141,
+            :admin_enable => true,
+            :management_address => '192.168.1.1'
+        } }
+
+        it 'should set rabbitmq_management port option to specified values' do
+          should contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          should contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          should contain_file('rabbitmq.config').with_content(%r{ip, "192.168.1.1"\}})
+          should contain_file('rabbitmq.config').with_content(%r{port, 3141\}})
+        end
+      end
+
+      describe 'admin ssl admin options and specific port set' do
+        let(:params) {
+          { :enable_management_ssl  => true,
+            :ssl_management_port => 3141,
+            :management_address => '192.168.1.1',
+            :ssl_cacert => '/path/to/cacert',
+            :ssl_cert => '/path/to/cert',
+            :ssl_key => '/path/to/key',
+            :admin_enable => true
+        } }
+
+        it 'should set rabbitmq_management ssl options to specified values' do
+          should contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          should contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          should contain_file('rabbitmq.config').with_content(%r{ip, "192.168.1.1"\}})
+          should contain_file('rabbitmq.config').with_content(%r{port, 3141\},})
+          should contain_file('rabbitmq.config').with_content(%r{ssl, true\},})
+          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
+          should contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
+          should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
+          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
         end
       end
 

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -59,7 +59,10 @@
 <%- if @admin_enable -%>,
   {rabbitmq_management, [
     {listener, [
-<%- if @ssl -%>
+    <%- if @enable_management_ssl -%>
+      <%- if @management_address != 'UNSET'-%>
+      {ip, "<%= @management_address %>"},
+      <%- end -%>
       {port, <%= @ssl_management_port %>},
       {ssl, true},
       {ssl_opts, [<%- if @ssl_cacert != 'UNSET' -%>{cacertfile, "<%= @ssl_cacert %>"},<%- end -%>
@@ -75,7 +78,10 @@
                   ]}
                   <%- end -%>
                  ]}
-<%- else -%>
+  <%- else -%>
+      <%- if @management_address != 'UNSET'-%>
+      {ip, "<%= @management_address %>"},
+      <%- end -%>
       {port, <%= @management_port %>}
 <%- end -%>
     ]}


### PR DESCRIPTION
Added management_address parameter to set the 'listener, ip' parameter to
specify the address the rabbitmq_management port should bind to instead
of the default all interfaces port, for example if we want localhost, or a specific address.

Also changed how the rabbitmq.conf template file determines if
the rabbitmq_management should use ssl by adding its own configuration
parameter which defaults to 'false' in case you don't want SSL listening
on our management interface.

Included rspec tests for new changes.