### PR TITLE
Added support for puppetlabs-apt >= 2.0

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -25,10 +25,11 @@ class rabbitmq::repo::apt(
     location    => $location,
     release     => $release,
     repos       => $repos,
-    include_src => $include_src,
-    key         => $key,
-    key_source  => $key_source,
-    key_content => $key_content,
+    key => {
+      id      => $key,
+      source  => $key_source,
+      content => $key_content
+    }
   }
 
   if $pin != '' {

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=2.0.0 <3.0.0"},
     {"name":"nanliu/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]
 }


### PR DESCRIPTION
This is needed for support of  puppetlabs-apt >= 2.0.