### PR TITLE
Loosen the apt dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,10 @@ The module has been tested on:
 
 Testing on other platforms has been light and cannot be guaranteed.
 
+### Apt module compatibility
+
+While this module supports both 1.x and 2.x versions of the puppetlabs-apt module, it does not support puppetlabs-apt 2.0.0 or 2.0.1.
+
 ### Module dependencies
 
 If running CentOS/RHEL, and using the yum provider, ensure the epel repo is present.

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
     {"name":"nanliu/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]
 }


### PR DESCRIPTION
Once puppetlabs-apt 2.1.0 is released (2015-06-16) the postgresql module
will be compatible with apt 1.x (>= 1.8.0) and 2.x (>= 2.1.0). This will
*not* work with puppetlabs-apt 2.0.x.