### PR TITLE
Fix "Invalid parameter include_src on Apt::Source[rabbitmq]"

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -21,14 +21,18 @@ class rabbitmq::repo::apt(
   }
 
   apt::source { 'rabbitmq':
-    ensure      => $ensure_source,
-    location    => $location,
-    release     => $release,
-    repos       => $repos,
-    include_src => $include_src,
-    key         => $key,
-    key_source  => $key_source,
-    key_content => $key_content,
+    ensure   => $ensure_source,
+    location => $location,
+    release  => $release,
+    repos    => $repos,
+    include  => {
+      'src' => $include_src,
+    },
+    key      => {
+      'id'      => $key,
+      'source'  => $key_source,
+      'content' => $key_content,
+    }
   }
 
   if $pin != '' {

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=2.0.0 <3.0.0"},
     {"name":"nanliu/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1169,11 +1169,17 @@ rabbitmq hard nofile 1234
       describe 'it sets up an apt::source' do
 
         it { should contain_apt__source('rabbitmq').with(
-          'location'    => 'http://www.rabbitmq.com/debian/',
-          'release'     => 'testing',
-          'repos'       => 'main',
-          'include_src' => false,
-          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
+          'location' => 'http://www.rabbitmq.com/debian/',
+          'release'  => 'testing',
+          'repos'    => 'main',
+          'include'  => {
+            'src' => false,
+          },
+          'key'      => {
+            'id'      => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
+            'source'  => 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+            'content' => :undef,
+          }
         ) }
       end
     end
@@ -1183,11 +1189,17 @@ rabbitmq hard nofile 1234
       describe 'it sets up an apt::source and pin' do
 
         it { should contain_apt__source('rabbitmq').with(
-          'location'    => 'http://www.rabbitmq.com/debian/',
-          'release'     => 'testing',
-          'repos'       => 'main',
-          'include_src' => false,
-          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
+          'location' => 'http://www.rabbitmq.com/debian/',
+          'release'  => 'testing',
+          'repos'    => 'main',
+          'include'  => {
+            'src' => false,
+          },
+          'key'      => {
+            'id'      => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
+            'source'  => 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+            'content' => :undef,
+          }
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
Using the latest version of puppetlabs-apt and the latest of puppetlabs-rabbitmq I get the following : 

Invalid parameter include_src on Apt::Source[rabbitmq] at /etc/puppet/environments/testing/modules/rabbitmq/manifests/repo/apt.pp:32 on node xxxxxx

This PR fix the error.

See : https://tickets.puppetlabs.com/browse/MODULES-2177