### PR TITLE
Revert "(MODULES-2177) Change apt::source for new apt module"

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -21,18 +21,14 @@ class rabbitmq::repo::apt(
   }
 
   apt::source { 'rabbitmq':
-    ensure   => $ensure_source,
-    location => $location,
-    release  => $release,
-    repos    => $repos,
-    include  => {
-      'src' => $include_src,
-    },
-    key      => {
-      'id'      => $key,
-      'source'  => $key_source,
-      'content' => $key_content,
-    }
+    ensure      => $ensure_source,
+    location    => $location,
+    release     => $release,
+    repos       => $repos,
+    include_src => $include_src,
+    key         => $key,
+    key_source  => $key_source,
+    key_content => $key_content,
   }
 
   if $pin != '' {

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">=2.0.0 <3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
     {"name":"nanliu/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1169,17 +1169,11 @@ rabbitmq hard nofile 1234
       describe 'it sets up an apt::source' do
 
         it { should contain_apt__source('rabbitmq').with(
-          'location' => 'http://www.rabbitmq.com/debian/',
-          'release'  => 'testing',
-          'repos'    => 'main',
-          'include'  => {
-            'src' => false,
-          },
-          'key'      => {
-            'id'      => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
-            'source'  => 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
-            'content' => :undef,
-          }
+          'location'    => 'http://www.rabbitmq.com/debian/',
+          'release'     => 'testing',
+          'repos'       => 'main',
+          'include_src' => false,
+          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
         ) }
       end
     end
@@ -1189,17 +1183,11 @@ rabbitmq hard nofile 1234
       describe 'it sets up an apt::source and pin' do
 
         it { should contain_apt__source('rabbitmq').with(
-          'location' => 'http://www.rabbitmq.com/debian/',
-          'release'  => 'testing',
-          'repos'    => 'main',
-          'include'  => {
-            'src' => false,
-          },
-          'key'      => {
-            'id'      => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
-            'source'  => 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
-            'content' => :undef,
-          }
+          'location'    => 'http://www.rabbitmq.com/debian/',
+          'release'     => 'testing',
+          'repos'       => 'main',
+          'include_src' => false,
+          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
This reverts commit 8587867ce9596201da22845cff57af003b4a7a07.

puppetlabs-apt 2.1.0 re-introduced the include_src parameter to avoid
breaking changes like this.

/cc @Pryz @cmurphy 