### PR TITLE
Fixing apt repo configuration, key should be key ID not key fingerprint

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,7 +6,7 @@ class rabbitmq::repo::apt(
   $release     = 'testing',
   $repos       = 'main',
   $include_src = false,
-  $key         = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
+  $key         = '0xF7B8CEA6056E8E56',
   $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
   $key_content = undef,
   ) {


### PR DESCRIPTION
when used with https://github.com/puppetlabs/puppetlabs-apt