### PR TITLE
remove "provider" property as it causes to fail when delete guest user is true

### DIFF
--- a/manifests/management.pp
+++ b/manifests/management.pp
@@ -6,7 +6,6 @@ class rabbitmq::management {
   if $delete_guest_user {
     rabbitmq_user{ 'guest':
       ensure   => absent,
-      provider => 'rabbitmqctl',
     }
   }
 


### PR DESCRIPTION
Hi,
there is no need to set the provider in rabbitmq_user class.
declaring it in management.pp makes puppet run to fail when delete_guest_user is set to true.
thanks
Daniel.

