### PR TITLE
Convert `max-length` policy to integer

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -96,6 +96,9 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     if definition.key? 'expires'
       definition['expires'] = definition['expires'].to_i
     end
+    if definition.key? 'max-length'
+      definition['max-length'] = definition['max-length'].to_i
+    end
     definition
   end
 end


### PR DESCRIPTION
`max-length` RabbitMQ policy value of string type doesn't pass validation:

    [root@rabbitmq-1 ~]# /sbin/rabbitmqctl set_policy -p echelon_amedia_production --priority 0 --apply-to queues echelon '.*' '{"max-length":"10000000"}'
    Setting policy "echelon" for pattern ".*" to "{\"max-length\":\"10000000\"}" with priority "0" ...
    Error: Validation failed

    <<"10000000">> is not a valid maximum length

but value of integer type pass validation:

    [root@rabbitmq-1 ~]# /sbin/rabbitmqctl set_policy -p echelon_amedia_production --priority 0 --apply-to queues echelon '.*' '{"max-length":10000000}'
    Setting policy "echelon" for pattern ".*" to "{\"max-length\":10000000}" with priority "0" ...

So, this PR convert `max-length` to integer.

P.S.
I wanted to add test but you are using RabbitMQ 3.1.5 which doesn't support `max-length` policy.