### PR TITLE
MODULES-2309: Add option to not notify service on config change

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ class { 'rabbitmq':
 }
 ```
 
+Setting up a cluster that comes up on its own, but isn't restarted automatically
+on configuration changes, so that a controlled restart can be done:
+
+```puppet
+class { 'rabbitmq':
+  config_cluster           => true,
+  cluster_nodes            => ['rabbit1', 'rabbit2'],
+  erlang_cookie            => 'A_SECRET_COOKIE_STRING',
+  service_notify           => false,
+  wipe_db_on_cookie_change => true,
+}
+```
+
 ##Reference
 
 ##Classes
@@ -334,6 +347,10 @@ Determines if the service is managed.
 ####`service_name`
 
 The name of the service to manage.
+
+####`service_notify`
+
+Determines if the service is notifed on configuration file changes.
 
 ####`ssl`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class rabbitmq(
   $service_ensure             = $rabbitmq::params::service_ensure,
   $service_manage             = $rabbitmq::params::service_manage,
   $service_name               = $rabbitmq::params::service_name,
+  $service_notify             = $rabbitmq::params::service_notify,
   $ssl                        = $rabbitmq::params::ssl,
   $ssl_only                   = $rabbitmq::params::ssl_only,
   $ssl_cacert                 = $rabbitmq::params::ssl_cacert,
@@ -107,6 +108,7 @@ class rabbitmq(
   validate_re($service_ensure, '^(running|stopped)$')
   validate_bool($service_manage)
   validate_string($service_name)
+  validate_bool($service_notify)
   validate_bool($ssl)
   validate_bool($ssl_only)
   validate_string($ssl_cacert)
@@ -227,9 +229,15 @@ class rabbitmq(
   anchor { 'rabbitmq::begin': }
   anchor { 'rabbitmq::end': }
 
-  Anchor['rabbitmq::begin'] -> Class['::rabbitmq::install']
-    -> Class['::rabbitmq::config'] ~> Class['::rabbitmq::service']
-    -> Class['::rabbitmq::management'] -> Anchor['rabbitmq::end']
+  if $service_notify {
+    Anchor['rabbitmq::begin'] -> Class['::rabbitmq::install']
+      -> Class['::rabbitmq::config'] ~> Class['::rabbitmq::service']
+      -> Class['::rabbitmq::management'] -> Anchor['rabbitmq::end']
+  } else {
+    Anchor['rabbitmq::begin'] -> Class['::rabbitmq::install']
+      -> Class['::rabbitmq::config'] -> Class['::rabbitmq::service']
+      -> Class['::rabbitmq::management'] -> Anchor['rabbitmq::end']
+  }
 
   # Make sure the various providers have their requirements in place.
   Class['::rabbitmq::install'] -> Rabbitmq_plugin<| |>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,6 +73,7 @@ class rabbitmq::params {
   $manage_repos               = undef
   $service_ensure             = 'running'
   $service_manage             = true
+  $service_notify             = true
   #config
   $cluster_node_type          = 'disc'
   $cluster_nodes              = []


### PR DESCRIPTION
This is to add the option to not notify the rabbitmq-service to restart after a configuration file change.

This is really only useful for HA rabbitmq clusters were you want to ensure that a controlled restart is done of all node on configuration changes.  Otherwise there is the chance of clustering issues if all nodes in the rabbitmq cluster are restarted simultaneously, as the current rabbitmq clustering configuration is highly dependent on the start order for node recovery.