### PR TITLE
(MODULES-2372) Convert message-ttl and max-length to integer

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -87,6 +87,18 @@ Puppet::Type.newtype(:rabbitmq_policy) do
         raise ArgumentError, "Invalid expires value '#{expires_val}'"
       end
     end
+    if definition.key? 'message-ttl'
+      message_ttl_val = definition['message-ttl']
+      unless message_ttl_val.to_i.to_s == message_ttl_val
+        raise ArgumentError, "Invalid message-ttl value '#{message_ttl_val}'"
+      end
+    end
+    if definition.key? 'max-length'
+      max_length_val = definition['max-length']
+      unless max_length_val.to_i.to_s == max_length_val
+        raise ArgumentError, "Invalid max-length value '#{max_length_val}'"
+      end
+    end
   end
 
   def munge_definition(definition)
@@ -95,6 +107,12 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     end
     if definition.key? 'expires'
       definition['expires'] = definition['expires'].to_i
+    end
+    if definition.key? 'message-ttl'
+      definition['message-ttl'] = definition['message-ttl'].to_i
+    end
+    if definition.key? 'max-length'
+      definition['max-length'] = definition['max-length'].to_i
     end
     definition
   end

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -116,4 +116,32 @@ describe Puppet::Type.type(:rabbitmq_policy) do
       @policy[:definition] = definition
     }.to raise_error(Puppet::Error, /Invalid expires value.*future/)
   end
+
+  it 'should accept and convert the message-ttl value' do
+    definition = {'message-ttl' => '1800000'}
+    @policy[:definition] = definition
+    @policy[:definition]['message-ttl'].should be_a(Fixnum)
+    @policy[:definition]['message-ttl'].should == 1800000
+  end
+
+  it 'should not accept non-numeric message-ttl value' do
+    definition = {'message-ttl' => 'future'}
+    expect {
+      @policy[:definition] = definition
+    }.to raise_error(Puppet::Error, /Invalid message-ttl value.*future/)
+  end
+
+  it 'should accept and convert the max-length value' do
+    definition = {'max-length' => '1800000'}
+    @policy[:definition] = definition
+    @policy[:definition]['max-length'].should be_a(Fixnum)
+    @policy[:definition]['max-length'].should == 1800000
+  end
+
+  it 'should not accept non-numeric max-length value' do
+    definition = {'max-length' => 'future'}
+    expect {
+      @policy[:definition] = definition
+    }.to raise_error(Puppet::Error, /Invalid max-length value.*future/)
+  end
 end


### PR DESCRIPTION
When setting message-ttl or max-length policies using rabbbitmq_policy
type the puppet execution fails because these two parameters are
passed as strings instead of integers to rabbitmqctl. This patch adds
the code to convert these two values to integer before using them.