### PR TITLE
add --tlsv1.1 flag to curl download of rabbitmqadmin so that the http…

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -16,7 +16,7 @@ class rabbitmq::install::rabbitmqadmin {
   staging::file { 'rabbitmqadmin':
     target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     source      => "${protocol}://${default_user}:${default_pass}@localhost:${management_port}/cli/rabbitmqadmin",
-    curl_option => '-k --noproxy localhost --retry 30 --retry-delay 6',
+    curl_option => '-k --tlsv1.1 --noproxy localhost --retry 30 --retry-delay 6',
     timeout     => '180',
     wget_option => '--no-proxy',
     require     => [


### PR DESCRIPTION
…s server doesn't reject the request with newer rabbitmq-server