### PR TITLE
Added heartbeat option to rabbitmq-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ set config_cluster to 'False' and set 'erlang_cookie'.
 Set rabbitmq file ulimit. Defaults to 16384. Only available on systems with
 `$::osfamily == 'Debian'` or `$::osfamily == 'RedHat'`.
 
+####`heartbeat`
+
+Set the heartbeat timeout interval, default is unset which uses the builtin server
+defaultsof 60 seconds. Setting this to `0` will disable heartbeats.
+
 ####`key_content`
 
 Uses content method for Debian OS family. Should be a template for apt::source

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,7 @@ class rabbitmq::config {
   $rabbitmq_home              = $rabbitmq::rabbitmq_home
   $port                       = $rabbitmq::port
   $tcp_keepalive              = $rabbitmq::tcp_keepalive
+  $heartbeat                  = $rabbitmq::heartbeat
   $service_name               = $rabbitmq::service_name
   $ssl                        = $rabbitmq::ssl
   $ssl_only                   = $rabbitmq::ssl_only

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class rabbitmq(
   $rabbitmq_home              = $rabbitmq::params::rabbitmq_home,
   $port                       = $rabbitmq::params::port,
   $tcp_keepalive              = $rabbitmq::params::tcp_keepalive,
+  $heartbeat                  = $rabbitmq::params::heartbeat,
   $service_ensure             = $rabbitmq::params::service_ensure,
   $service_manage             = $rabbitmq::params::service_manage,
   $service_name               = $rabbitmq::params::service_name,
@@ -145,7 +146,11 @@ class rabbitmq(
   validate_hash($config_variables)
   validate_hash($config_kernel_variables)
   validate_hash($config_management_variables)
-  
+
+  if $heartbeat {
+    validate_integer($heartbeat)
+  }
+
   if $auth_backends {
     validate_array($auth_backends)
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,6 +92,7 @@ class rabbitmq::params {
   $node_ip_address            = 'UNSET'
   $port                       = '5672'
   $tcp_keepalive              = false
+  $heartbeat                  = undef
   $ssl                        = false
   $ssl_only                   = false
   $ssl_cacert                 = 'UNSET'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1195,6 +1195,23 @@ LimitNOFILE=1234
         end
       end
 
+      describe 'rabbitmq-heartbeat options' do
+        let(:params) {{ :heartbeat => 60 }}
+        it 'should set heartbeat paramter in config file' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{heartbeat, 60\}/)
+        end
+      end
+
+      describe 'non-integer rabbitmq-heartbeat options' do
+        let(:params) {{ :heartbeat => 'string' }}
+        it 'should raise a validation error' do
+          expect {
+            should contain_file('rabbitmq.config')
+          }.to raise_error(Puppet::Error, /Expected first argument to be an Integer/)
+        end
+      end
+
       context 'delete_guest_user' do
         describe 'should do nothing by default' do
           it { should_not contain_rabbitmq_user('guest') }

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -5,6 +5,9 @@
   {ssl, [{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}]},
 <%- end -%>
   {rabbit, [
+<%- if @heartbeat -%>
+    {heartbeat, <%=@heartbeat%>},
+<% end -%>
 <% if @auth_backends -%>
     {auth_backends, [<%= @auth_backends.map { |v| "#{v}" }.join(', ') %>]},
 <% elsif @ldap_auth -%>


### PR DESCRIPTION
Added the rabbitmq config option `heartbeat` to provide a heartbeat
connection to nodes. By default this option isn't set in rabbitmq.conf
and its package default is 580 seconds, if the option is set, the config
will reflect this change. There are no other config changes required.

This change was made as we use the particular option in our implementation
and it wasn't in the module.

Spec tests provided.