### PR TITLE
Install file limits snippet to limits.d on EL7

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -139,14 +139,13 @@ class rabbitmq::config {
           notify      => Class['Rabbitmq::Service'],
           refreshonly => true,
         }
-      } else {
-        file { '/etc/security/limits.d/rabbitmq-server.conf':
-          content => template('rabbitmq/limits.conf'),
-          owner   => '0',
-          group   => '0',
-          mode    => '0644',
-          notify  => Class['Rabbitmq::Service'],
-        }
+      }
+      file { '/etc/security/limits.d/rabbitmq-server.conf':
+        content => template('rabbitmq/limits.conf'),
+        owner   => '0',
+        group   => '0',
+        mode    => '0644',
+        notify  => Class['Rabbitmq::Service'],
       }
     }
     default: {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -181,6 +181,72 @@ describe 'rabbitmq' do
       should contain_class('rabbitmq::repo::rhel')
       should contain_exec('rpm --import http://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
     end
+
+    context 'with file_limit => \'unlimited\'' do
+      let(:params) {{ :file_limit => 'unlimited' }}
+      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+        'owner'   => '0',
+        'group'   => '0',
+        'mode'    => '0644',
+        'notify'  => 'Class[Rabbitmq::Service]',
+        'content' => 'rabbitmq soft nofile unlimited
+rabbitmq hard nofile unlimited
+'
+      ) }
+    end
+
+    context 'with file_limit => \'infinity\'' do
+      let(:params) {{ :file_limit => 'infinity' }}
+      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+        'owner'   => '0',
+        'group'   => '0',
+        'mode'    => '0644',
+        'notify'  => 'Class[Rabbitmq::Service]',
+        'content' => 'rabbitmq soft nofile infinity
+rabbitmq hard nofile infinity
+'
+      ) }
+    end
+
+    context 'with file_limit => \'-1\'' do
+      let(:params) {{ :file_limit => '-1' }}
+      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+        'owner'   => '0',
+        'group'   => '0',
+        'mode'    => '0644',
+        'notify'  => 'Class[Rabbitmq::Service]',
+        'content' => 'rabbitmq soft nofile -1
+rabbitmq hard nofile -1
+'
+      ) }
+    end
+
+    context 'with file_limit => \'1234\'' do
+      let(:params) {{ :file_limit => '1234' }}
+      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+        'owner'   => '0',
+        'group'   => '0',
+        'mode'    => '0644',
+        'notify'  => 'Class[Rabbitmq::Service]',
+        'content' => 'rabbitmq soft nofile 1234
+rabbitmq hard nofile 1234
+'
+      ) }
+    end
+
+    context 'with file_limit => \'-42\'' do
+      let(:params) {{ :file_limit => '-42' }}
+      it 'does not compile' do
+        expect { catalogue }.to raise_error(Puppet::Error, /\$file_limit must be a positive integer, '-1', 'unlimited', or 'infinity'/)
+      end
+    end
+
+    context 'with file_limit => \'foo\'' do
+      let(:params) {{ :file_limit => 'foo' }}
+      it 'does not compile' do
+        expect { catalogue }.to raise_error(Puppet::Error, /\$file_limit must be a positive integer, '-1', 'unlimited', or 'infinity'/)
+      end
+    end
   end
 
   context 'on Redhat' do
@@ -321,90 +387,6 @@ LimitNOFILE=-1
 LimitNOFILE=1234
 '
       ) }
-    end
-
-    context 'with file_limit => \'-42\'' do
-      let(:params) {{ :file_limit => '-42' }}
-      it 'does not compile' do
-        expect { catalogue }.to raise_error(Puppet::Error, /\$file_limit must be a positive integer, '-1', 'unlimited', or 'infinity'/)
-      end
-    end
-
-    context 'with file_limit => \'foo\'' do
-      let(:params) {{ :file_limit => 'foo' }}
-      it 'does not compile' do
-        expect { catalogue }.to raise_error(Puppet::Error, /\$file_limit must be a positive integer, '-1', 'unlimited', or 'infinity'/)
-      end
-    end
-  end
-
-  context 'on RedHat before 7.0' do
-    let(:facts) {{ :osfamily => 'RedHat', :operatingsystemmajrelease => '6' }}
-
-    context 'with file_limit => \'unlimited\'' do
-      let(:params) {{ :file_limit => 'unlimited' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
-        'owner'   => '0',
-        'group'   => '0',
-        'mode'    => '0644',
-        'notify'  => 'Class[Rabbitmq::Service]',
-        'content' => 'rabbitmq soft nofile unlimited
-rabbitmq hard nofile unlimited
-'
-      ) }
-    end
-
-    context 'with file_limit => \'infinity\'' do
-      let(:params) {{ :file_limit => 'infinity' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
-        'owner'   => '0',
-        'group'   => '0',
-        'mode'    => '0644',
-        'notify'  => 'Class[Rabbitmq::Service]',
-        'content' => 'rabbitmq soft nofile infinity
-rabbitmq hard nofile infinity
-'
-      ) }
-    end
-
-    context 'with file_limit => \'-1\'' do
-      let(:params) {{ :file_limit => '-1' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
-        'owner'   => '0',
-        'group'   => '0',
-        'mode'    => '0644',
-        'notify'  => 'Class[Rabbitmq::Service]',
-        'content' => 'rabbitmq soft nofile -1
-rabbitmq hard nofile -1
-'
-      ) }
-    end
-
-    context 'with file_limit => \'1234\'' do
-      let(:params) {{ :file_limit => '1234' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
-        'owner'   => '0',
-        'group'   => '0',
-        'mode'    => '0644',
-        'notify'  => 'Class[Rabbitmq::Service]',
-        'content' => 'rabbitmq soft nofile 1234
-rabbitmq hard nofile 1234
-'
-      ) }
-    end
-
-    context 'with file_limit => \'-42\'' do
-      let(:params) {{ :file_limit => '-42' }}
-      it 'does not compile' do
-        expect { catalogue }.to raise_error(Puppet::Error, /\$file_limit must be a positive integer, '-1', 'unlimited', or 'infinity'/)
-      end
-    end
-
-    context 'with file_limit => \'foo\'' do
-      let(:params) {{ :file_limit => 'foo' }}
-      it 'does not compile' do
-        expect { catalogue }.to raise_error(Puppet::Error, /\$file_limit must be a positive integer, '-1', 'unlimited', or 'infinity'/)
-      end
     end
   end
 


### PR DESCRIPTION
It is possible for the RabbitMQ service to be managed by something
other than systemd on EL7.  An example is when pacemaker is managing
RabbitMQ in an HA cluster.  In this use case, the systemd limits will
have no effect, but it is still desirable to set the file descriptor
limit.