### PR TITLE
Ignore incoming federated exchanges

### DIFF
--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -38,6 +38,9 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, :parent => Puppet:
     self.run_with_retries {
       rabbitmqctl('-q', 'list_exchanges', '-p', vhost, 'name', 'type', 'internal', 'durable', 'auto_delete', 'arguments')
     }.split(/\n/).each do |exchange|
+      if exchange =~ /^federation:/
+        next
+      end
       exchanges.push(exchange)
     end
     exchanges


### PR DESCRIPTION
Federated exchanges are created automatically when running federation and if there is any federation running  manifest will fail with:
Could not prefetch rabbitmq_exchange provider 'rabbitmqadmin': 746: unexpected token at 'x-federation-upstream'
