### PR TITLE
Ignore system umask when generating enabled_plugins file.

### DIFF
--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -34,7 +34,11 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, :parent => Puppet:
   end
 
   def create
-    rabbitmqplugins('enable', resource[:name])
+    if resource[:umask] == nil
+      rabbitmqplugins('enable', resource[:name])
+    else
+      Puppet::Util::withumask(resource[:umask]) { rabbitmqplugins('enable', resource[:name]) }
+    end
   end
 
   def destroy

--- a/lib/puppet/type/rabbitmq_plugin.rb
+++ b/lib/puppet/type/rabbitmq_plugin.rb
@@ -16,4 +16,16 @@ Puppet::Type.newtype(:rabbitmq_plugin) do
     newvalues(/^\S+$/)
   end
 
+  newparam(:umask) do
+    desc "Sets the octal umask to be used while creating this resource"
+    defaultto '0022'
+    munge do |value|
+      if value =~ /^0?[0-7]{1,3}$/
+        return value.to_i(8)
+      else
+        raise Puppet::Error, "The umask specification is invalid: #{value.inspect}"
+      end
+    end
+  end
+
 end

--- a/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
@@ -1,0 +1,24 @@
+require 'puppet'
+require 'puppet/type/rabbitmq_plugin'
+describe Puppet::Type.type(:rabbitmq_plugin) do
+  before :each do
+    @plugin = Puppet::Type.type(:rabbitmq_plugin).new(:name => 'foo')
+  end
+  it 'should accept a plugin name' do
+    @plugin[:name] = 'plugin-name'
+    @plugin[:name].should == 'plugin-name'
+  end
+  it 'should require a name' do
+    expect {
+      Puppet::Type.type(:rabbitmq_plugin).new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+  it 'should default to a umask of 0022' do
+    @plugin[:umask].should == 0022
+  end
+  it 'should not allow a non-octal value to be specified' do
+    expect {
+      @plugin[:umask] = '198'
+    }.to raise_error(Puppet::Error, /The umask specification is invalid: "198"/)
+  end
+end


### PR DESCRIPTION
The file /etc/rabbitmq/enabled_plugins should to be owned by root and
world readable.  To ensure this happens, this module needs to ignore
the system wide umask whenever it recreates the file.  This then
sidesteps the scenario where a rabbitmq process, running under a
separate daemon account, is no longer able to access its own file.