### PR TITLE
Add parameter to configure only the SSL port for STOMP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,11 @@ Functionality can be tested with cipherscan or similar tool: https://github.com/
 
 The port to use for Stomp.
 
+####`stomp_ssl_only`
+
+Configures STOMP to only use SSL.  No cleartext STOMP TCP listeners will be created.
+Requires setting ssl_stomp_port also.
+
 ####`stomp_ensure`
 
 Boolean to install the stomp plugin.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,6 +40,7 @@ class rabbitmq::config {
   $ssl_versions               = $rabbitmq::ssl_versions
   $ssl_ciphers                = $rabbitmq::ssl_ciphers
   $stomp_port                 = $rabbitmq::stomp_port
+  $stomp_ssl_only             = $rabbitmq::stomp_ssl_only
   $ldap_auth                  = $rabbitmq::ldap_auth
   $ldap_server                = $rabbitmq::ldap_server
   $ldap_user_dn_pattern       = $rabbitmq::ldap_user_dn_pattern

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class rabbitmq(
   $ldap_log                   = $rabbitmq::params::ldap_log,
   $ldap_config_variables      = $rabbitmq::params::ldap_config_variables,
   $stomp_port                 = $rabbitmq::params::stomp_port,
+  $stomp_ssl_only             = $rabbitmq::params::stomp_ssl_only,
   $version                    = $rabbitmq::params::version,
   $wipe_db_on_cookie_change   = $rabbitmq::params::wipe_db_on_cookie_change,
   $cluster_partition_handling = $rabbitmq::params::cluster_partition_handling,
@@ -123,6 +124,7 @@ class rabbitmq(
     validate_re($ssl_stomp_port, '\d+')
   }
   validate_bool($stomp_ensure)
+  validate_bool($stomp_ssl_only)
   validate_bool($ldap_auth)
   validate_string($ldap_server)
   validate_string($ldap_user_dn_pattern)
@@ -141,6 +143,10 @@ class rabbitmq(
 
   if $config_stomp and $ssl_stomp_port and ! $ssl {
     warning('$ssl_stomp_port requires that $ssl => true and will be ignored')
+  }
+
+  if $config_stomp and $stomp_ssl_only and ! $ssl_stomp_port  {
+    fail('$stomp_ssl_only requires that $ssl_stomp_port be set')
   }
 
   if $ssl_versions {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -113,6 +113,7 @@ class rabbitmq::params {
   $ldap_log                   = false
   $ldap_config_variables      = {}
   $stomp_port                 = '61613'
+  $stomp_ssl_only             = false
   $wipe_db_on_cookie_change   = false
   $cluster_partition_handling = 'ignore'
   $environment_variables      = {}

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -94,8 +94,13 @@
 <% if @config_stomp -%>,
 % Configure the Stomp Plugin listening port
   {rabbitmq_stomp, [
+  <%- if @stomp_ssl_only -%>
+    {tcp_listeners, []}
+  <%- else -%>
     {tcp_listeners, [<%= @stomp_port %>]}
-  <%- if @ssl && @ssl_stomp_port -%>,
+  <%- end -%>
+  <%- if @ssl && @ssl_stomp_port -%>
+    ,
     {ssl_listeners, [<%= @ssl_stomp_port %>]}
   <%- end -%>
   ]}


### PR DESCRIPTION
This PR adds a parameter to configure only the SSL port for STOMP plugin.

I've added related parameter doc in README.md. I didn't add tests because there are very few tests about stomp and none about ssl_stomp_port.