### PR TITLE
Add support to uninstall rabbitmq plugins.

### DIFF
--- a/lib/puppet/parser/functions/convert_to_ensurable.rb
+++ b/lib/puppet/parser/functions/convert_to_ensurable.rb
@@ -1,0 +1,18 @@
+#
+# convert_to_ensurable.rb
+#
+# Simple converter function to map boolean values into their 'ensurable' counterparts, :present & :absent
+#
+module Puppet::Parser::Functions
+  newfunction(:convert_to_ensurable, :type => :rvalue, :doc => <<-EOS
+Simple converter function to map a boolean value into its 'ensurable' counterpart
+    EOS
+  ) do |arguments|
+    raise(Puppet::ParseError, "convert_to_ensurable(): Expected one argument") if arguments.size < 1
+    case arguments[0]
+      when false then return :absent
+      when true  then return :present
+      else raise(Puppet::ParseError, 'convert_to_ensurable(): Expected boolean argument')
+    end
+  end
+end


### PR DESCRIPTION
The module does not currently support removal of plugins once they have been installed.  While the system will remove any added configuration, this merely means that the plugin will run in its default configuration.  In order to disable the plugin properly, we need to support removal.