### PR TITLE
Add support to uninstall rabbitmq plugins.

### DIFF
--- a/lib/puppet/parser/functions/convert_to_ensurable.rb
+++ b/lib/puppet/parser/functions/convert_to_ensurable.rb
@@ -1,0 +1,18 @@
+#
+# convert_to_ensurable.rb
+#
+# Simple converter function to map boolean values into their 'ensurable' counterparts, :present & :absent
+#
+module Puppet::Parser::Functions
+  newfunction(:convert_to_ensurable, :type => :rvalue, :doc => <<-EOS
+Simple converter function to map a boolean value into its 'ensurable' counterpart
+    EOS
+  ) do |arguments|
+    raise(Puppet::ParseError, "convert_to_ensurable(): Expected one argument") if arguments.size < 1
+    case arguments[0]
+      when false then return :absent
+      when true  then return :present
+      else raise(Puppet::ParseError, 'convert_to_ensurable(): Expected boolean argument')
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,33 +195,30 @@ class rabbitmq(
     }
   }
 
-  if $admin_enable and $service_manage {
+  $admin_ensure = $admin_enable and $service_manage
+
+  if $admin_ensure {
     include '::rabbitmq::install::rabbitmqadmin'
-
-    rabbitmq_plugin { 'rabbitmq_management':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
-
     Class['::rabbitmq::service'] -> Class['::rabbitmq::install::rabbitmqadmin']
     Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
   }
 
-  if $stomp_ensure {
-    rabbitmq_plugin { 'rabbitmq_stomp':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
+  rabbitmq_plugin { 'rabbitmq_management':
+    ensure  => convert_to_ensurable($admin_ensure),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
   }
 
-  if ($ldap_auth) {
-    rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
+  rabbitmq_plugin { 'rabbitmq_stomp':
+    ensure  => convert_to_ensurable($stomp_ensure),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
+  }
+
+  rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
+    ensure  => convert_to_ensurable($ldap_auth),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
   }
 
   anchor { 'rabbitmq::begin': }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -408,6 +408,7 @@ LimitNOFILE=1234
           it 'we enable the admin interface by default' do
             should contain_class('rabbitmq::install::rabbitmqadmin')
             should contain_rabbitmq_plugin('rabbitmq_management').with(
+              'ensure'  => 'present',
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
@@ -431,7 +432,11 @@ LimitNOFILE=1234
           let(:params) {{ :admin_enable => true, :service_manage => false }}
           it 'should do nothing' do
             should_not contain_class('rabbitmq::install::rabbitmqadmin')
-            should_not contain_rabbitmq_plugin('rabbitmq_management')
+            should contain_rabbitmq_plugin('rabbitmq_management').with(
+              'ensure'  => 'absent',
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            )
           end
         end
       end
@@ -728,7 +733,7 @@ LimitNOFILE=1234
             %r{keyfile,"/path/to/key"}
           )
         end
-        it 'should set ssl managment port to specified values' do 
+        it 'should set ssl managment port to specified values' do
           should contain_file('rabbitmq.config').with_content(
             %r{port, 13141}
           )


### PR DESCRIPTION
The module does not currently support removal of plugins once they have been installed. While the system will remove any added configuration, this merely means that the plugin will run in its default configuration. In order to disable the plugin properly, we need to support removal.