### PR TITLE
Add support for rabbitmq_mqtt plugin.

### DIFF
--- a/lib/puppet/parser/functions/convert_to_ensurable.rb
+++ b/lib/puppet/parser/functions/convert_to_ensurable.rb
@@ -1,0 +1,18 @@
+#
+# convert_to_ensurable.rb
+#
+# Simple converter function to map boolean values into their 'ensurable' counterparts, :present & :absent
+#
+module Puppet::Parser::Functions
+  newfunction(:convert_to_ensurable, :type => :rvalue, :doc => <<-EOS
+Simple converter function to map a boolean value into its 'ensurable' counterpart
+    EOS
+  ) do |arguments|
+    raise(Puppet::ParseError, "convert_to_ensurable(): Expected one argument") if arguments.size < 1
+    case arguments[0]
+      when false then return :absent
+      when true  then return :present
+      else raise(Puppet::ParseError, 'convert_to_ensurable(): Expected boolean argument')
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,33 +195,30 @@ class rabbitmq(
     }
   }
 
-  if $admin_enable and $service_manage {
+  $admin_ensure = $admin_enable and $service_manage
+
+  if $admin_ensure {
     include '::rabbitmq::install::rabbitmqadmin'
-
-    rabbitmq_plugin { 'rabbitmq_management':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
-
     Class['::rabbitmq::service'] -> Class['::rabbitmq::install::rabbitmqadmin']
     Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
   }
 
-  if $stomp_ensure {
-    rabbitmq_plugin { 'rabbitmq_stomp':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
+  rabbitmq_plugin { 'rabbitmq_management':
+    ensure  => convert_to_ensurable($admin_ensure),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
   }
 
-  if ($ldap_auth) {
-    rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
+  rabbitmq_plugin { 'rabbitmq_stomp':
+    ensure  => convert_to_ensurable($stomp_ensure),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
+  }
+
+  rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
+    ensure  => convert_to_ensurable($ldap_auth),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
   }
 
   anchor { 'rabbitmq::begin': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class rabbitmq(
   $config_cluster             = $rabbitmq::params::config_cluster,
   $config_path                = $rabbitmq::params::config_path,
   $config_stomp               = $rabbitmq::params::config_stomp,
+  $config_mqtt                = $rabbitmq::params::config_mqtt,
   $default_user               = $rabbitmq::params::default_user,
   $default_pass               = $rabbitmq::params::default_pass,
   $delete_guest_user          = $rabbitmq::params::delete_guest_user,
@@ -65,6 +66,18 @@ class rabbitmq(
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
   $key_content                = undef,
+  $mqtt_ensure                = $rabbitmq::params::mqtt_ensure,
+  $mqtt_port                  = $rabbitmq::params::mqtt_port,
+  $mqtt_ssl_port              = $rabbitmq::params::mqtt_ssl_port,
+  $mqtt_allow_anonymous       = $rabbitmq::params::mqtt_allow_anonymous,
+  $mqtt_default_user          = $rabbitmq::params::mqtt_default_user,
+  $mqtt_default_pass          = $rabbitmq::params::mqtt_default_pass,
+  $mqtt_default_vhost         = $rabbitmq::params::mqtt_default_vhost,
+  $mqtt_default_exchange      = $rabbitmq::params::mqtt_default_exchange,
+  $mqtt_subscription_ttl      = $rabbitmq::params::mqtt_subscription_ttl,
+  $mqtt_prefetch              = $rabbitmq::params::mqtt_prefetch,
+  $mqtt_ssl_cert_login        = $rabbitmq::params::mqtt_ssl_cert_login,
+
 ) inherits rabbitmq::params {
 
   validate_bool($admin_enable)
@@ -83,6 +96,7 @@ class rabbitmq(
   validate_absolute_path($config_path)
   validate_bool($config_cluster)
   validate_bool($config_stomp)
+  validate_bool($config_mqtt)
   validate_string($default_user)
   validate_string($default_pass)
   validate_bool($delete_guest_user)
@@ -134,6 +148,22 @@ class rabbitmq(
   validate_hash($environment_variables)
   validate_hash($config_variables)
   validate_hash($config_kernel_variables)
+
+  validate_bool($mqtt_ensure)
+  if ! is_integer($mqtt_port) {
+    validate_re($mqtt_port, '\d+')
+  }
+  if ! is_integer($mqtt_ssl_port) {
+    validate_re($mqtt_ssl_port, '\d+')
+  }
+  validate_bool($mqtt_allow_anonymous)
+  validate_string($mqtt_default_user)
+  validate_string($mqtt_default_pass)
+  validate_string($mqtt_default_vhost)
+  validate_string($mqtt_default_exchange)
+  validate_re($mqtt_subscription_ttl, '\d+')
+  validate_re($mqtt_prefetch, '\d+')
+  validate_bool($mqtt_ssl_cert_login)
 
   if $ssl_only and ! $ssl {
     fail('$ssl_only => true requires that $ssl => true')
@@ -211,6 +241,12 @@ class rabbitmq(
 
   rabbitmq_plugin { 'rabbitmq_stomp':
     ensure  => convert_to_ensurable($stomp_ensure),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
+  }
+
+  rabbitmq_plugin { 'rabbitmq_mqtt':
+    ensure  => convert_to_ensurable($mqtt_ensure),
     require => Class['rabbitmq::install'],
     notify  => Class['rabbitmq::service'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,6 +80,7 @@ class rabbitmq::params {
   $config_cluster             = false
   $config_path                = '/etc/rabbitmq/rabbitmq.config'
   $config_stomp               = false
+  $config_mqtt                = false
   $default_user               = 'guest'
   $default_pass               = 'guest'
   $delete_guest_user          = false
@@ -119,4 +120,15 @@ class rabbitmq::params {
   $config_variables           = {}
   $config_kernel_variables    = {}
   $file_limit                 = '16384'
+  $mqtt_ensure                = false
+  $mqtt_port                  = '1883'
+  $mqtt_ssl_port              = '8883'
+  $mqtt_allow_anonymous       = false
+  $mqtt_default_user          = 'guest'
+  $mqtt_default_pass          = 'guest'
+  $mqtt_default_vhost         = "/"
+  $mqtt_default_exchange      = "amq.topic"
+  $mqtt_subscription_ttl      = 1800000
+  $mqtt_prefetch              = 10
+  $mqtt_ssl_cert_login        = false
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -408,6 +408,7 @@ LimitNOFILE=1234
           it 'we enable the admin interface by default' do
             should contain_class('rabbitmq::install::rabbitmqadmin')
             should contain_rabbitmq_plugin('rabbitmq_management').with(
+              'ensure'  => 'present',
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
@@ -431,7 +432,11 @@ LimitNOFILE=1234
           let(:params) {{ :admin_enable => true, :service_manage => false }}
           it 'should do nothing' do
             should_not contain_class('rabbitmq::install::rabbitmqadmin')
-            should_not contain_rabbitmq_plugin('rabbitmq_management')
+            should contain_rabbitmq_plugin('rabbitmq_management').with(
+              'ensure'  => 'absent',
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            )
           end
         end
       end
@@ -728,7 +733,7 @@ LimitNOFILE=1234
             %r{keyfile,"/path/to/key"}
           )
         end
-        it 'should set ssl managment port to specified values' do 
+        it 'should set ssl managment port to specified values' do
           should contain_file('rabbitmq.config').with_content(
             %r{port, 13141}
           )

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -402,7 +402,7 @@ LimitNOFILE=1234
       it { should contain_class('rabbitmq::config') }
       it { should contain_class('rabbitmq::service') }
 
-     context 'with admin_enable set to true' do
+      context 'with admin_enable set to true' do
         let(:params) {{ :admin_enable => true }}
         context 'with service_manage set to true' do
           it 'we enable the admin interface by default' do
@@ -1061,6 +1061,149 @@ LimitNOFILE=1234
               'ensure'   => 'absent',
               'provider' => 'rabbitmqctl'
             )
+          end
+        end
+      end
+
+      ##
+      ## Message Queue Telemetry Transport (MQTT) Plugin
+      ##
+      context 'running the rabbitmq_mqtt plugin' do
+        context 'with mqtt_ensure set to true' do
+          let(:params) {{ :mqtt_ensure => true }}
+          it 'it should ensure the plugin is present' do
+            should contain_rabbitmq_plugin('rabbitmq_mqtt').with(
+              'ensure'  => 'present',
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            )
+          end
+        end
+        context 'with mqtt_ensure set to false' do
+          let(:params) {{ :mqtt_ensure => false }}
+          it 'it should ensure the plugin is absent' do
+            should contain_rabbitmq_plugin('rabbitmq_mqtt').with(
+              'ensure'  => 'absent',
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            )
+          end
+        end
+        context 'with config_mqtt set to true' do
+          let(:params) {{
+            :config_mqtt           => true,
+            :mqtt_allow_anonymous  => true,
+            :mqtt_default_user     => 'TESTUSER',
+            :mqtt_default_pass     => 'TESTPASSWORD',
+            :mqtt_default_vhost    => '/VTEST',
+            :mqtt_default_exchange => 'default.topic',
+            :mqtt_subscription_ttl => 150000,
+            :mqtt_prefetch         => 95,
+            :mqtt_ssl_cert_login   => true
+          }}
+          it 'it should specify rabbitmq_mqtt parameters in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt/)
+          end
+          it 'it should specify the rabbitmq_mqtt default_user parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*default_user, <<"TESTUSER">>/m)
+          end
+          it 'it should specify the rabbitmq_mqtt default_pass parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*default_pass, <<"TESTPASSWORD">>/m)
+          end
+          it 'it should specify the rabbitmq_mqtt allow_anonymous parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*allow_anonymous, true/m)
+          end
+          it 'it should specify the rabbitmq_mqtt vhost parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*vhost, <<"\/VTEST">>/m)
+          end
+          it 'it should specify the rabbitmq_mqtt exchange parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*exchange, <<"default.topic">>/m)
+          end
+          it 'it should specify the rabbitmq_mqtt subscription_ttl parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*subscription_ttl, 150000/m)
+          end
+          it 'it should specify the rabbitmq_mqtt prefetch parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*prefetch, 95/m)
+          end
+          it 'it should specify the rabbitmq_mqtt ssl_cert_login parameter in rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*ssl_cert_login, true/m)
+          end
+        end
+        context 'with config_mqtt set to false' do
+          let(:params) {{ :config_mqtt => false }}
+          it 'it should not specify rabbitmq_mqtt parameters in rabbitmq.config' do
+            should contain_file('rabbitmq.config').without_content(/rabbitmq_mqtt/)
+          end
+        end
+        context 'when ssl_only is enabled' do
+          let(:params) {{
+            :config_mqtt   => true,
+            :ssl           => true,
+            :ssl_only      => true,
+            :mqtt_ssl_port => '8883'
+          }}
+          it 'should specify empty listeners for rabbitmq_mqtt in the rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*listeners, \[\]/m)
+          end
+        end
+        context 'when ssl_only is disabled' do
+          context 'when the interface is specified' do
+            let(:params) {{
+              :config_mqtt => true,
+              :ssl         => false,
+              :ssl_only    => false,
+              :interface   => '127.0.0.1',
+              :mqtt_port   => '1883'
+            }}
+            it 'should specify interface bound listeners for rabbitmq_mqtt in the rabbitmq.config' do
+              should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*listeners, \[\{"127.0.0.1", 1883\}\]/m)
+            end
+          end
+          context 'when the ssl_interface is not specified' do
+            let(:params) {{
+              :config_mqtt => true,
+              :ssl         => false,
+              :ssl_only    => false,
+              :interface   => 'UNSET',
+              :mqtt_port   => '1884'
+            }}
+            it 'should specify interface free listeners for rabbitmq_mqtt in the rabbitmq.config' do
+              should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*listeners, \[1884\]/m)
+            end
+          end
+        end
+        context 'when ssl is disabled' do
+          let(:params) {{
+            :config_mqtt   => true,
+            :ssl           => false,
+            :mqtt_ssl_port => '8883'
+          }}
+          it 'should specify empty ssl_listeners for rabbitmq_mqtt in the rabbitmq.config' do
+            should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*ssl_listeners, \[\]/m)
+          end
+        end
+        context 'when ssl is enabled' do
+          context 'when the ssl_interface is specified' do
+            let(:params) {{
+              :config_mqtt   => true,
+              :ssl           => true,
+              :ssl_interface => '127.0.0.1',
+              :mqtt_ssl_port => '8883'
+            }}
+            it 'should specify interface bound ssl_listeners for rabbitmq_mqtt in the rabbitmq.config' do
+              should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*ssl_listeners, \[\{"127.0.0.1", 8883\}\]/m)
+            end
+          end
+          context 'when the ssl_interface is not specified' do
+            let(:params) {{
+              :config_mqtt   => true,
+              :ssl           => true,
+              :ssl_interface => 'UNSET',
+              :mqtt_ssl_port => '8884'
+            }}
+            it 'should specify interface free ssl_listeners for rabbitmq_mqtt in the rabbitmq.config' do
+              should contain_file('rabbitmq.config').with_content(/rabbitmq_mqtt.*ssl_listeners, \[8884\]/m)
+            end
           end
         end
       end

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -116,5 +116,45 @@
     {log, <%= @ldap_log %>}
   ]}
 <%- end -%>
+<% if @config_mqtt -%>,
+% Configure the Message Queue Telemetry Transport Plugin
+  {rabbitmq_mqtt, [
+    {default_user, <<"<%= @mqtt_default_user %>">>},
+    {default_pass, <<"<%= @mqtt_default_pass %>">>},
+    {allow_anonymous, <%= @mqtt_allow_anonymous %>},
+    {vhost, <<"<%= @mqtt_default_vhost %>">>},
+    {exchange, <<"<%= @mqtt_default_exchange %>">>},
+    {subscription_ttl, <%= @mqtt_subscription_ttl %>},
+    {prefetch, <%= @mqtt_prefetch %>},
+  <%- if @mqtt_ssl_cert_login -%>
+    {ssl_cert_login, <%= @mqtt_ssl_cert_login %>},
+  <%- end -%>
+  <%- if @ssl && @ssl_interface != 'UNSET' -%>
+    {ssl_listeners, [{"<%= @ssl_interface %>", <%= @mqtt_ssl_port %>}]},
+  <%- elsif @ssl -%>
+    {ssl_listeners, [<%= @mqtt_ssl_port %>]},
+  <%- else -%>
+    {ssl_listeners, []},
+  <%- end -%>
+  <%- if @ssl_only -%>
+    {tcp_listeners, []},
+  <%- elsif @interface != 'UNSET' -%>
+    {tcp_listeners, [{"<%= @interface %>", <%= @mqtt_port %>}]},
+  <%- else -%>
+    {tcp_listeners, [<%= @mqtt_port %>]},
+  <%- end -%>
+    {tcp_listen_options,
+         [binary,
+         <%- if @tcp_keepalive -%>
+         {keepalive, true},
+         <%- end -%>
+         {packet, raw},
+         {reuseaddr, true},
+         {backlog, 128},
+         {nodelay, true},
+         {exit_on_close, false}
+    ]}
+  ]}
+<% end -%>
 ].
 % EOF


### PR DESCRIPTION
This adds general support for the Message Queue Telemetry Transport (MQTT) Plugin.

Has a dependency on the following pull request:
>   Add support to uninstall rabbitmq plugins. 
>   #388 opened 2 days ago by acowan 