### PR TITLE
Allow integer values for $file_limit

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,7 +103,9 @@ class rabbitmq(
   }
   validate_bool($wipe_db_on_cookie_change)
   validate_bool($tcp_keepalive)
-  validate_re($file_limit, '^(\d+|-1|unlimited|infinity)$', '$file_limit must be a positive integer, \'-1\', \'unlimited\', or \'infinity\'.')
+  # using sprintf for conversion to string, because "${file_limit}" doesn't
+  # pass lint, despite being nicer
+  validate_re(sprintf('%s', $file_limit), '^(\d+|-1|unlimited|infinity)$', '$file_limit must be a positive integer, \'-1\', \'unlimited\', or \'infinity\'.')
   # Validate service parameters.
   validate_re($service_ensure, '^(running|stopped)$')
   validate_bool($service_manage)

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -160,6 +160,11 @@ describe 'rabbitmq' do
       it { should contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n 1234/) }
     end
 
+    context 'with file_limit => 1234' do
+      let(:params) {{ :file_limit => 1234 }}
+      it { should contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n 1234/) }
+    end
+
     context 'with file_limit => \'-42\'' do
       let(:params) {{ :file_limit => '-42' }}
       it 'does not compile' do


### PR DESCRIPTION
(This is another try at implementing #400 . AFAIK github doesn't allow pull request amendment by a different person so i'm sending a new pull request.)

Previously errors were thrown when $file_limit was integer, as
validate_re() function only works with strings. $file_limit
is now casted to string before passing it to validate_re().