### PR TITLE
Update ruby.rb

### DIFF
--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
 
   defaultfor :feature => :posix
   has_command(:puppet, 'puppet') do
-    environment :PATH => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
+  #  environment :PATH => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
   end
 
   def exists?


### PR DESCRIPTION
Fixes RVM implementations.  When the path is hard set, for some reason that is beyond me, and a the path gets overwritten, then puppet and ruby can not be found.  W/O this, RVM works again