### PR TITLE
Avoid starting rabbitmq processes as root

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,6 +201,15 @@ class rabbitmq(
     }
   }
 
+  # Start epmd as rabbitmq so it doesn't run as root when installing plugins 
+  exec { 'epmd_daemon':
+    command => 'epmd -daemon',
+    path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+    user    => $rabbitmq_user,
+    group   => $rabbitmq_group,
+    unless  => 'pgrep epmd',
+  }
+
   if $admin_enable and $service_manage {
     include '::rabbitmq::install::rabbitmqadmin'
 
@@ -238,6 +247,7 @@ class rabbitmq(
     -> Class['::rabbitmq::management'] -> Anchor['rabbitmq::end']
 
   # Make sure the various providers have their requirements in place.
-  Class['::rabbitmq::install'] -> Rabbitmq_plugin<| |>
+  Class['::rabbitmq::install'] -> Exec['epmd_daemon']
+    -> Rabbitmq_plugin<| |>
 
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -3,17 +3,21 @@ require 'spec_helper_acceptance'
 describe 'rabbitmq class:' do
   case fact('osfamily')
   when 'RedHat'
-    package_name = 'rabbitmq-server'
-    service_name = 'rabbitmq-server'
+    package_name  = 'rabbitmq-server'
+    service_name  = 'rabbitmq-server'
+    rabbitmq_user = 'rabbitmq'
   when 'SUSE'
-    package_name = 'rabbitmq-server'
-    service_name = 'rabbitmq-server'
+    package_name  = 'rabbitmq-server'
+    service_name  = 'rabbitmq-server'
+    rabbitmq_user = 'rabbitmq'
   when 'Debian'
-    package_name = 'rabbitmq-server'
-    service_name = 'rabbitmq-server'
+    package_name  = 'rabbitmq-server'
+    service_name  = 'rabbitmq-server'
+    rabbitmq_user = 'rabbitmq'
   when 'Archlinux'
-    package_name = 'rabbitmq'
-    service_name = 'rabbitmq'
+    package_name  = 'rabbitmq'
+    service_name  = 'rabbitmq'
+    rabbitmq_user = 'rabbitmq'
   end
 
   context "default class inclusion" do
@@ -32,12 +36,18 @@ describe 'rabbitmq class:' do
     end
 
     describe package(package_name) do
-      it { should be_installed }      
+      it { should be_installed }
     end
 
     describe service(service_name) do
       it { should be_enabled }
       it { should be_running }
+    end
+    it 'should have run as rabbitmq_user' do
+      shell('ps haxo user,cmd | egrep -v "su |grep " | egrep "rabbit|epmd|beam"') do |r|
+        expect(r.stdout).to match(/^#{rabbitmq_user}.*/)
+        expect(r.exit_code).to be_zero
+      end
     end
   end
 


### PR DESCRIPTION
Rabbitmq-plugins must be run as root
(in order to set /etc/rabbitmq/enabled_plugins), but as
a consequence, it starts epmd and leaves it running.
This can be worked around by starting epmd as rabbitmq
user before evaluating any plugins.
