### PR TITLE
Fixing pinning for apt on Debian based distros

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -32,10 +32,11 @@ class rabbitmq::repo::apt(
   }
 
   if $pin != '' {
-    validate_re($pin, '\d\d\d')
+    validate_re($pin, '\d{1,4}')
     apt::pin { 'rabbitmq':
-      packages => 'rabbitmq-server',
+      packages => '*',
       priority => $pin,
+      origin   => 'www.rabbitmq.com',
     }
   }
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1173,8 +1173,9 @@ LimitNOFILE=1234
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(
-          'packages' => 'rabbitmq-server',
-          'priority' => '700'
+          'packages' => '*',
+          'priority' => '700',
+          'origin'   => 'www.rabbitmq.com'
         ) }
 
       end


### PR DESCRIPTION
APT pinning can use 4 digit values. How it was done it was pinning all rabbitmq-server packages (even those provided by other origins) this should fix it to the point that only packages provided by www.rabbitmq.com will be pinned