### PR TITLE
Add the config_rabbitmq_management_variables param

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ class { 'rabbitmq':
 }
 ```
 
+To change Management Plugin Config Variables in rabbitmq.config, use the parameters
+`config_management_variables` e.g.:
+
+```puppet
+class { 'rabbitmq':
+  config_management_variables  => {
+    'rates_mode' => 'basic',
+  }
+}
+```
+
 ### Clustering
 To use RabbitMQ clustering facilities, use the rabbitmq parameters
 `config_cluster`, `cluster_nodes`, and `cluster_node_type`, e.g.:
@@ -191,6 +202,10 @@ the queue. You can read more about it
 ####`config_path`
 
 The path to write the RabbitMQ configuration file to.
+
+####`config_management_variables`
+
+Hash of configuration variables for the [Management Plugin](https://www.rabbitmq.com/management.html).
 
 ####`config_stomp`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,6 +54,7 @@ class rabbitmq::config {
   $wipe_db_on_cookie_change   = $rabbitmq::wipe_db_on_cookie_change
   $config_variables           = $rabbitmq::config_variables
   $config_kernel_variables    = $rabbitmq::config_kernel_variables
+  $config_management_variables = $rabbitmq::config_management_variables
   $auth_backends              = $rabbitmq::auth_backends
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $file_limit                 = $rabbitmq::file_limit

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class rabbitmq(
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
+  $config_management_variables = $rabbitmq::config_management_variables,
   $auth_backends              = $rabbitmq::params::auth_backends,
   $key_content                = undef,
 ) inherits rabbitmq::params {
@@ -143,6 +144,7 @@ class rabbitmq(
   validate_hash($environment_variables)
   validate_hash($config_variables)
   validate_hash($config_kernel_variables)
+  validate_hash($config_management_variables)
   
   if $auth_backends {
     validate_array($auth_backends)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,6 +121,7 @@ class rabbitmq::params {
   $environment_variables      = {}
   $config_variables           = {}
   $config_kernel_variables    = {}
+  $config_management_variables = {}
   $auth_backends              = undef
   $file_limit                 = '16384'
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1158,6 +1158,16 @@ LimitNOFILE=1234
         end
       end
 
+      describe 'config_management_variables' do                                                                                              
+        let(:params) {{ :config_management_variables => {
+            'rates_mode'      => 'none',
+        }}}
+        it 'should set config variables' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{rates_mode, none\}/)
+        end
+      end
+
       describe 'tcp_keepalive enabled' do
         let(:params) {{ :tcp_keepalive => true }}
         it 'should set tcp_listen_options keepalive true' do

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -66,6 +66,11 @@
     <%= @config_kernel_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
   ]}
 <%- end -%>
+<% if @config_management_variables -%>,
+  {rabbitmq_management, [
+    <%= @config_management_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
+  ]}
+<%- end -%>
 <%- if @admin_enable -%>,
   {rabbitmq_management, [
     {listener, [


### PR DESCRIPTION
Allow to configure the parameters like rabbitmq_management.rates_mode,
which are important for production use and high loaded systems.

Closes-bug: #MODULES-2754

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>