### PR TITLE
MODULES-2252 - fix "Command execution expired" issue

### DIFF
--- a/lib/puppet/provider/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmqctl.rb
@@ -19,7 +19,7 @@ class Puppet::Provider::Rabbitmqctl < Puppet::Provider
         output = Timeout::timeout(timeout) do
           yield
         end
-      rescue Puppet::ExecutionFailure, Timeout
+      rescue Puppet::ExecutionFailure, Timeout::Error
         Puppet.debug 'Command failed, retrying'
         sleep step
       else


### PR DESCRIPTION
This addresses the issue at: https://tickets.puppetlabs.com/browse/MODULES-2252  - we experienced this issue at various occasions, and seems to mostly occur when the server in question is under high load. The `Timeout` exception caught in the `rabbitmqctl.rb` provider is not being caught correctly, leading to all RabbitMQ resources not being retried, and timing out with a generic `execution expired` message.

I've confirmed this change in our PRD and STG environments, and it improves the situation - we've not experienced another resource timeout since making this change.