### PR TITLE
Change cluster_node_type description in Readme.md - MODULES-2786

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Boolean, if enabled sets up the management interface/plugin for RabbitMQ.
 
 ####`cluster_node_type`
 
-Choose between disk and ram nodes.
+Choose between disc and ram nodes.
 
 ####`cluster_nodes`
 


### PR DESCRIPTION
Change option description from disk to disc, as the actual parameter value needs to be "disc" or "ram"