### PR TITLE
Better error when policy definition value is not a string

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -72,7 +72,7 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     end
     definition.each do |k,v|
       unless [String].include?(v.class)
-        raise ArgumentError, "Invalid definition"
+        raise ArgumentError, "Invalid definition, value #{v} is not a string"
       end
     end
     if definition['ha-mode'] == 'exactly'


### PR DESCRIPTION
Hello,

I was using this module to create a policy and was stumped why `create_resources` wasn't working with something like the following mock hiera data:

```
queue-limit@vhost:
  pattern: '^foobar$'
  priority: 1
  applyto: 'queues'
  definition:
    'max-length': 1000000
```

I received the following errors in my puppet run:

```
puppet-agent[26841]: Failed to apply catalog: Parameter definition failed on Rabbitmq_policy[queue-limit@vhost]: Invalid definition
puppet-agent[26841]: Wrapped exception:
puppet-agent[26841]: Invalid definition
puppet-agent[26841]: Wrapped exception:
puppet-agent[26841]: Invalid definition
```

This change makes the error message for non-string definition values more verbose.

I did not make a ticket for this as it is (what I would consider to be) cosmetic and not vital to the functionality of the module.  If I must make a ticket per the contribution guidelines, please let me know and I will be happy to make an account to do so.