### PR TITLE
MODULES-2252 - fix "Could not prefetch rabbitmq_exchange provider 'rabbitmqadmin': 757: unexpected token at 'fanout'" issue

### DIFF
--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -38,6 +38,7 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, :parent => Puppet:
     self.run_with_retries {
       rabbitmqctl('-q', 'list_exchanges', '-p', vhost, 'name', 'type', 'internal', 'durable', 'auto_delete', 'arguments')
     }.split(/\n/).each do |exchange|
+      next if exchange =~ /^federation:/
       exchanges.push(exchange)
     end
     exchanges


### PR DESCRIPTION
Skips federated exchanges in the output, as these have a different set of fields, and cause issues when they're parsed.