### PR TITLE
Fix incompatability with latest puppet

### DIFF
--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -3,9 +3,14 @@ require 'set'
 Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
 
   defaultfor :feature => :posix
-  has_command(:puppet, 'puppet') do
-    environment :PATH => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
+
+  env_path = '/opt/puppetlabs/bin:/usr/local/bin:/usr/bin:/bin'
+  puppet_path = Puppet::Util.withenv(:PATH => env_path) do
+    Puppet::Util.which('puppet')
   end
+
+  confine :false => puppet_path.nil?
+  has_command(:puppet, puppet_path) unless puppet_path.nil?
 
   def exists?
     # Hack to prevent the create method from being called.


### PR DESCRIPTION
This fixes an issue with the latest version of puppet when run from a cron job, which does not include "/opt/puppetlabs/bin" in the PATH that the cron jobs see. The other issue with the current implementation is that, in the latest puppet code at least, the custom_environment that's being set in the block given to `has_command` is not used when resolving the location of the command.

To reproduce the issue, run `PATH=/usr/bin:/bin sudo /opt/puppetlabs/bin/puppet agent --test`