### PR TITLE
Use yum as package provider for RedHat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class rabbitmq::params {
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq-server'
       $service_name     = 'rabbitmq-server'
-      $package_provider = 'rpm'
+      $package_provider = 'yum'
       $version          = '3.1.5-1'
       $rabbitmq_user    = 'rabbitmq'
       $rabbitmq_group   = 'rabbitmq'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1128,7 +1128,7 @@ LimitNOFILE=1234
       should contain_package('rabbitmq-server').with(
         'ensure'   => 'installed',
         'name'     => 'rabbitmq-server',
-        'provider' => 'rpm',
+        'provider' => 'yum',
         'source'   => 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.2.3/rabbitmq-server-3.2.3-1.noarch.rpm'
       )
     end


### PR DESCRIPTION
I noticed that with `epel` enabled, `yum` can resolve the erlang dependencies of rabbitmq without the help of additional puppet erlang modules on CentOs7. Since `epel` is needed on both CentOS and RedHat, maybe its safe to use `yum` as the package provider for them instead of `rpm`.