### PR TITLE
Ensure an apt-update after change repository so we can get upstream version

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -13,7 +13,10 @@ class rabbitmq::repo::apt(
 
   $pin = $rabbitmq::package_apt_pin
 
-  Class['rabbitmq::repo::apt'] -> Package<| title == 'rabbitmq-server' |>
+  # ordering / ensure to get the last version of repository
+  Class['rabbitmq::repo::apt']
+  -> Class['apt::update']
+  -> Package<| title == 'rabbitmq-server' |>
 
   $ensure_source = $rabbitmq::repos_ensure ? {
     false   => 'absent',


### PR DESCRIPTION
I needed 3.6.0 version for rabbitmq, which was handled by custom debian repo, but no apt-update was done after. I was then stuck at 3.3.5.

