### PR TITLE
Update apt::source to match with new method

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -29,10 +29,14 @@ class rabbitmq::repo::apt(
     location     => $location,
     release      => $release,
     repos        => $repos,
-    include_src  => $include_src,
-    key          => $key,
-    key_source   => $key_source,
-    key_content  => $key_content,
+    include      => {
+      'src' => $include_src
+    },
+    key          => {
+      'id'      => $key,
+      'source'  => $key_source,
+      'content' => $key_content,
+    },
     architecture => $architecture,
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
-    {"name":"puppet/staging","version_requirement":">=0.3.1 <2.0.0"}
+    {"name":"puppet/staging","version_requirement":">=0.3.1 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=2.0.0 <3.0.0"}
   ]
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1422,11 +1422,17 @@ LimitNOFILE=1234
       describe 'it sets up an apt::source' do
 
         it { should contain_apt__source('rabbitmq').with(
-          'location'    => 'http://www.rabbitmq.com/debian/',
-          'release'     => 'testing',
-          'repos'       => 'main',
-          'include_src' => false,
-          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          'location' => 'http://www.rabbitmq.com/debian/',
+          'release'  => 'testing',
+          'repos'    => 'main',
+          'include'  => {
+            'src' => false,
+          },
+          'key'      => {
+            'id'      => '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
+            'source'  => 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc',
+            'content' => 'undef',
+          }
         ) }
       end
     end
@@ -1436,11 +1442,17 @@ LimitNOFILE=1234
       describe 'it sets up an apt::source and pin' do
 
         it { should contain_apt__source('rabbitmq').with(
-          'location'    => 'http://www.rabbitmq.com/debian/',
-          'release'     => 'testing',
-          'repos'       => 'main',
-          'include_src' => false,
-          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          'location' => 'http://www.rabbitmq.com/debian/',
+          'release'  => 'testing',
+          'repos'    => 'main',
+          'include'  => {
+            'src' => false,
+          },
+          'key'      => {
+            'id'      => '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
+            'source'  => 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc',
+            'content' => 'undef',
+          }
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
puppetlabs-apt recently did some changes that brings warnings when we
run puppetlabs-rabbitmq, because we need to update the way we consume
apt module.

$include_src is deprecated and will be removed in the next major
release, please use $include => { 'src' => false } instead

$key_source is deprecated and will be removed in the next major release,
please use $key => { 'source' =>
http://www.rabbitmq.com/rabbitmq-signing-key-public.asc } instead.

This patch aims to update the way we use puppetlabs-apt to match with
upstream and avoid warnings in our catalog.
