### PR TITLE
RedHat Systemd variables Restart, StartLimitInterval, StartLimitBurst…

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,12 @@ Location of RabbitMQ plugins.
 
 The RabbitMQ port.
 
+####`restart_param`
+
+Only available on systems with `$::osfamily == 'RedHat'`. Systemd variable
+that specifies application's restart tendency. Default is 'no'.
+Use with start_limit_interval and start_limit_burst to control restart attempts.
+
 ####`service_ensure`
 
 The state of the service.
@@ -415,6 +421,13 @@ Support only a given list of SSL ciphers. Example: `['dhe_rsa,aes_256_cbc,sha','
 Supported ciphers in your install can be listed with:
  rabbitmqctl eval 'ssl:cipher_suites().'
 Functionality can be tested with cipherscan or similar tool: https://github.com/jvehent/cipherscan.git
+
+####`start_limit_burst`
+
+ Only available on systems with `$::osfamily == 'RedHat'`. Systemd variable, default '3'.
+
+####`start_limit_interval`
+ Only available on systems with `$::osfamily == 'RedHat'`. Systemd variable that, default '60s'
 
 ####`stomp_port`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -58,6 +58,9 @@ class rabbitmq::config {
   $auth_backends              = $rabbitmq::auth_backends
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $file_limit                 = $rabbitmq::file_limit
+  $restart_param              = $rabbitmq::restart_param
+  $start_limit_interval       = $rabbitmq::start_limit_interval
+  $start_limit_burst          = $rabbitmq::start_limit_burst
   $default_env_variables      =  {
     'NODE_PORT'        => $port,
     'NODE_IP_ADDRESS'  => $node_ip_address

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,9 @@ class rabbitmq(
   $wipe_db_on_cookie_change   = $rabbitmq::params::wipe_db_on_cookie_change,
   $cluster_partition_handling = $rabbitmq::params::cluster_partition_handling,
   $file_limit                 = $rabbitmq::params::file_limit,
+  $restart_param              = $rabbitmq::params::restart_param,
+  $start_limit_interval       = $rabbitmq::params::start_limit_interval,
+  $start_limit_burst          = $rabbitmq::params::start_limit_burst,
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
@@ -109,6 +112,9 @@ class rabbitmq(
   }
   validate_bool($wipe_db_on_cookie_change)
   validate_bool($tcp_keepalive)
+  validate_string($restart_param)
+  validate_string($start_limit_interval)
+  validate_string($start_limit_burst)
   # using sprintf for conversion to string, because "${file_limit}" doesn't
   # pass lint, despite being nicer
   validate_re(sprintf('%s', $file_limit), '^(\d+|-1|unlimited|infinity)$', '$file_limit must be a positive integer, \'-1\', \'unlimited\', or \'infinity\'.')
@@ -145,7 +151,7 @@ class rabbitmq(
   validate_hash($config_variables)
   validate_hash($config_kernel_variables)
   validate_hash($config_management_variables)
-  
+
   if $auth_backends {
     validate_array($auth_backends)
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -124,4 +124,7 @@ class rabbitmq::params {
   $config_management_variables = {}
   $auth_backends              = undef
   $file_limit                 = '16384'
+  $start_limit_interval       = '60s'
+  $start_limit_burst          = '3'
+  $restart_param              = 'no'
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -351,6 +351,9 @@ rabbitmq hard nofile 1234
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=unlimited
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
@@ -364,6 +367,9 @@ LimitNOFILE=unlimited
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=infinity
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
@@ -377,6 +383,9 @@ LimitNOFILE=infinity
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=-1
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
@@ -390,9 +399,30 @@ LimitNOFILE=-1
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=1234
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
+   context 'with restart_params=on-failure' do
+      let(:params) {{ :file_limit => '1234',
+                      :restart_param => 'on-failure',
+                      :start_limit_interval => '30s',
+                      :start_limit_burst => '5' }}
+      it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
+        'owner'   => '0',
+        'group'   => '0',
+        'mode'    => '0644',
+        'notify'  => 'Exec[rabbitmq-systemd-reload]',
+        'content' => '[Service]
+LimitNOFILE=1234
+Restart=on-failure
+StartLimitInterval=30s
+StartLimitBurst=5
+'
+     )}
+   end
   end
 
   ['Debian', 'RedHat', 'SUSE', 'Archlinux'].each do |distro|
@@ -658,7 +688,7 @@ LimitNOFILE=1234
                             '    {port, 389},', '    {foo, bar},', '    {log, true}'])
         end
       end
-      
+
       describe 'configuring auth_backends' do
         let :params do
           { :auth_backends   => ['{baz, foo}', 'bar'] }
@@ -1158,7 +1188,7 @@ LimitNOFILE=1234
         end
       end
 
-      describe 'config_management_variables' do                                                                                              
+      describe 'config_management_variables' do
         let(:params) {{ :config_management_variables => {
             'rates_mode'      => 'none',
         }}}

--- a/templates/rabbitmq-server.service.d/limits.conf
+++ b/templates/rabbitmq-server.service.d/limits.conf
@@ -1,2 +1,5 @@
 [Service]
 LimitNOFILE=<%= @file_limit %>
+Restart=<%= @restart_param %>
+StartLimitInterval=<%= @start_limit_interval %>
+StartLimitBurst=<%= @start_limit_burst %>


### PR DESCRIPTION
Allows for automation of restarting rabbitmq-server on RedHat operating systems. 
(of note if you configure for clustering it does bring up node within cluster again)

- By setting restart_param to  one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always, you can control how/if Systemd daemon's restarts the rabbitmq-server.

- start_limit_burst control and start_limit_interval  respectively control how many times over what period of time the daemon attempts to restart the rabbitmq-server.

Systemd Service Man Page
[http://www.freedesktop.org/software/systemd/man/systemd.service.html ](url)