### PR TITLE
fix federation queue for error: Could not prefetch rabbitmq_queue provider 'rabbitmqadmin': 757: unexpected token

### DIFF
--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -39,6 +39,7 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
     resources = []
     all_vhosts.each do |vhost|
       all_queues(vhost).collect do |line|
+        next if line =~ /^federation:/
         name, durable, auto_delete, arguments = line.split()
         # Convert output of arguments from the rabbitmqctl command to a json string.
         if !arguments.nil?


### PR DESCRIPTION
An error similar as #412, skips federated queues in the output.