### PR TITLE
Fix rabbitmqadmin url

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -12,10 +12,11 @@ class rabbitmq::install::rabbitmqadmin {
 
   $default_user = $rabbitmq::default_user
   $default_pass = $rabbitmq::default_pass
+  $node_ip_address = $rabbitmq::node_ip_address
 
   staging::file { 'rabbitmqadmin':
     target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
-    source      => "${protocol}://${default_user}:${default_pass}@localhost:${management_port}/cli/rabbitmqadmin",
+    source      => "${protocol}://${default_user}:${default_pass}@${node_ip_address}:${management_port}/cli/rabbitmqadmin",
     curl_option => '-k --noproxy localhost --retry 30 --retry-delay 6',
     timeout     => '180',
     wget_option => '--no-proxy',

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -420,7 +420,7 @@ LimitNOFILE=1234
       it { should contain_class('rabbitmq::service') }
 
      context 'with admin_enable set to true' do
-        let(:params) {{ :admin_enable => true }}
+        let(:params) {{ :admin_enable => true, :node_ip_address => '1.1.1.1' }}
         context 'with service_manage set to true' do
           it 'we enable the admin interface by default' do
             should contain_class('rabbitmq::install::rabbitmqadmin')
@@ -428,20 +428,20 @@ LimitNOFILE=1234
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
-            should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@localhost:15672/cli/rabbitmqadmin")
+            should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@1.1.1.1:15672/cli/rabbitmqadmin")
           end
         end
         context 'with service_manage set to true and default user/pass specified' do
-          let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2' }}
+          let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2', :node_ip_address => '1.1.1.1' }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with_source("http://foobar:hunter2@localhost:15672/cli/rabbitmqadmin")
+            should contain_staging__file('rabbitmqadmin').with_source("http://foobar:hunter2@1.1.1.1:15672/cli/rabbitmqadmin")
           end
         end
         context 'with service_manage set to true and management port specified' do
           # note that the 2.x management port is 55672 not 15672
-          let(:params) {{ :admin_enable => true, :management_port => '55672' }}
+          let(:params) {{ :admin_enable => true, :management_port => '55672', :node_ip_address => '1.1.1.1' }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@localhost:55672/cli/rabbitmqadmin")
+            should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@1.1.1.1:55672/cli/rabbitmqadmin")
           end
         end
         context 'with service_manage set to false' do
@@ -658,7 +658,7 @@ LimitNOFILE=1234
                             '    {port, 389},', '    {foo, bar},', '    {log, true}'])
         end
       end
-      
+
       describe 'configuring auth_backends' do
         let :params do
           { :auth_backends   => ['{baz, foo}', 'bar'] }
@@ -1158,7 +1158,7 @@ LimitNOFILE=1234
         end
       end
 
-      describe 'config_management_variables' do                                                                                              
+      describe 'config_management_variables' do
         let(:params) {{ :config_management_variables => {
             'rates_mode'      => 'none',
         }}}


### PR DESCRIPTION
When trying to get rabbitmqadmin the manifest
sends request to localhost which is wrong since
node_ip_address can differ.
