### PR TITLE
Added Erlang cookie generation to avoid chicken-and-egg issue

### DIFF
--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -36,7 +36,10 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
     if File.exists?(resource[:path])
       File.read(resource[:path])
     else
-      ''
+      # Yep, we said we only want to update resources.
+      # But we can't change what doesn't exist. Without this creating clusters is bothersome.
+      # Worst case scenario: we generate a random 20 character uppercase alpha cookie instead of erlang.
+      ('A'..'Z').to_a.shuffle[0,20].join
     end
   end
 


### PR DESCRIPTION
Hi guys,

Whilst it's been said we want to avoid actually creating resources, when puppetizing the creation of a RabbitMQ cluster this becomes bothersome with regard to Erlang cookies.

Puppet will want to update a resource that doesn't yet exist (or is empty) and therefore will bomb out. With this, we create a random and completely acceptable Erlang cookie just so that we can sacrifice it to the Gods, to replace it with our own defined cookie.

Either way, RabbitMQ will end up creating a cookie randomly itself, so this can't really do any harm and will only get around this annoyance.

In my use case (first run in both examples) I went from this:

```
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/File[rabbitmq.config]: Dependency Rabbitmq_erlang_cookie[/var/lib/rabbitmq/.erlang.cookie] has failures: true
==> sensu01: Error: no implicit conversion of Hash into String
==> sensu01: Error: /Stage[main]/Rabbitmq::Config/Rabbitmq_erlang_cookie[/var/lib/rabbitmq/.erlang.cookie]/content: change from  to <MY 20 CHARACTER STRING> failed: no implicit conversion of Hash into String
==> sensu01: Warning: /Stage[main]/Rabbitmq::Config/File[rabbitmq.config]: Skipping because of failed dependencies
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/File[/etc/security/limits.d/rabbitmq-server.conf]/ensure: defined content as '{md5}5ddc6ba5fcaeddd5b1565e5adfda5236'
==> sensu01: Info: /Stage[main]/Rabbitmq::Config/File[/etc/security/limits.d/rabbitmq-server.conf]: Scheduling refresh of Class[Rabbitmq::Service]
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/File[rabbitmq-env.config]/ensure: defined content as '{md5}d1faed99ee5f85f2e3ef458c2d19f3a8'
```

To this:

```
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/File[/etc/rabbitmq/ssl]/ensure: created
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/Rabbitmq_erlang_cookie[/var/lib/rabbitmq/.erlang.cookie]/content: The rabbitmq erlang cookie was changed
==> sensu01: Info: /Stage[main]/Rabbitmq::Config/Rabbitmq_erlang_cookie[/var/lib/rabbitmq/.erlang.cookie]: Scheduling refresh of Class[Rabbitmq::Service]
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/File[rabbitmq.config]/ensure: defined content as '{md5}9f8e2853a25ab56e3e402df83a458eb8'
==> sensu01: Info: /Stage[main]/Rabbitmq::Config/File[rabbitmq.config]: Scheduling refresh of Class[Rabbitmq::Service]
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/File[/etc/security/limits.d/rabbitmq-server.conf]/ensure: defined content as '{md5}5ddc6ba5fcaeddd5b1565e5adfda5236'
==> sensu01: Info: /Stage[main]/Rabbitmq::Config/File[/etc/security/limits.d/rabbitmq-server.conf]: Scheduling refresh of Class[Rabbitmq::Service]
==> sensu01: Notice: /Stage[main]/Rabbitmq::Config/File[rabbitmq-env.config]/ensure: defined content as '{md5}d1faed99ee5f85f2e3ef458c2d19f3a8'
```

There may well be better ways to fix this, but this was my first thought upon encountering the issue, and it's one that personally I find acceptable in my use case. Never the less, I'd welcome any discussion!

Cheers,

Chris