### PR TITLE
Allow passing architecture to `apt::source`

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -2,13 +2,14 @@
 #   puppetlabs-apt
 #   puppetlabs-stdlib
 class rabbitmq::repo::apt(
-  $location    = 'http://www.rabbitmq.com/debian/',
-  $release     = 'testing',
-  $repos       = 'main',
-  $include_src = false,
-  $key         = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
-  $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
-  $key_content = undef,
+  $location     = 'http://www.rabbitmq.com/debian/',
+  $release      = 'testing',
+  $repos        = 'main',
+  $include_src  = false,
+  $key          = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
+  $key_source   = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+  $key_content  = undef,
+  $architecture = undef,
   ) {
 
   $pin = $rabbitmq::package_apt_pin
@@ -24,14 +25,15 @@ class rabbitmq::repo::apt(
   }
 
   apt::source { 'rabbitmq':
-    ensure      => $ensure_source,
-    location    => $location,
-    release     => $release,
-    repos       => $repos,
-    include_src => $include_src,
-    key         => $key,
-    key_source  => $key_source,
-    key_content => $key_content,
+    ensure       => $ensure_source,
+    location     => $location,
+    release      => $release,
+    repos        => $repos,
+    include_src  => $include_src,
+    key          => $key,
+    key_source   => $key_source,
+    key_content  => $key_content,
+    architecture => $architecture,
   }
 
   if $pin != '' {


### PR DESCRIPTION
It's useful to be able to set this parameter on `apt::source`.

I've defaulted this param to `undef` which is the same as the default in `apt::source`.