### PR TITLE
curl --noproxy value should be dynamically set

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -17,7 +17,7 @@ class rabbitmq::install::rabbitmqadmin {
   staging::file { 'rabbitmqadmin':
     target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     source      => "${protocol}://${default_user}:${default_pass}@${node_ip_address}:${management_port}/cli/rabbitmqadmin",
-    curl_option => '-k --noproxy localhost --retry 30 --retry-delay 6',
+    curl_option => "-k --noproxy ${node_ip_address} --retry 30 --retry-delay 6",
     timeout     => '180',
     wget_option => '--no-proxy',
     require     => [


### PR DESCRIPTION
We currently hardcoded it to localhost which will still cause issues
when rabbitmq tries to connect to an ip which isn't listening on
localhost for various reasons.

This improvement will make sure that our curl operation always matches
the current ip address used by rabbitmq