### PR TITLE
Change $repos_ensure to default to false.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,7 +71,7 @@ class rabbitmq::params {
   $management_ssl              = true
   $package_apt_pin             = ''
   $package_gpg_key             = 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc'
-  $repos_ensure                = true
+  $repos_ensure                = false
   $manage_repos                = undef
   $service_ensure              = 'running'
   $service_manage              = true

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -12,6 +12,7 @@ describe 'rabbitmq' do
 
   context 'on Debian' do
     with_debian_facts
+    let(:params) {{ :repos_ensure => true }}
     it 'includes rabbitmq::repo::apt' do
       should contain_class('rabbitmq::repo::apt')
     end
@@ -37,7 +38,7 @@ describe 'rabbitmq' do
   end
 
   context 'on Debian' do
-    let(:params) {{ :manage_repos => true }}
+    let(:params) {{ :manage_repos => true, :repos_ensure => true }}
     with_debian_facts
 
     it 'includes rabbitmq::repo::apt' do
@@ -182,6 +183,7 @@ describe 'rabbitmq' do
 
   context 'on Redhat' do
     with_redhat_facts
+    let(:params) {{ :repos_ensure => true }}
     it 'includes rabbitmq::repo::rhel' do
       should contain_class('rabbitmq::repo::rhel')
       should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
@@ -282,9 +284,9 @@ rabbitmq hard nofile 1234
   end
 
   context 'on Redhat' do
-    let(:params) {{ :manage_repos => true }}
+    let(:params) {{ :manage_repos => true, :repos_ensure => true }}
     with_redhat_facts
-    it 'does import repo public key when manage_repos is true' do
+    it 'does import repo public key when manage_repos and repos_ensure are true' do
       should contain_class('rabbitmq::repo::rhel')
       should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
     end
@@ -1419,7 +1421,8 @@ LimitNOFILE=1234
     describe "repo management on #{distro}" do
       describe 'imports the key' do
         let(:facts) { osfacts }
-        let(:params) {{ :package_gpg_key => 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc' }}
+        let(:params) {{ :package_gpg_key => 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+                        :manage_repos => true, :repos_ensure => true }}
 
         it { should contain_exec("rpm --import #{params[:package_gpg_key]}").with(
           'path' => ['/bin','/usr/bin','/sbin','/usr/sbin']


### PR DESCRIPTION
The problem with it being true by default is that the majority of production
environments, and any in an isolated nextwork, will not want to get the gpg key,
especially if they have not explicitly configured the module to get the rpm from
the rabbitmq repos.  Having the gpg key pulled in by default while installing
the rpm from distro repos seems inconsistent at best, and at worst, causes an
additional fail point for deployments that are unable to contact this location.
Leaving it true by default forces the majority of production users to have to
override this setting.
