### PR TITLE
MODULES-3148: Allow shards-per-node for rabbitmq_policy definition to be integer

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -99,6 +99,12 @@ Puppet::Type.newtype(:rabbitmq_policy) do
         raise ArgumentError, "Invalid max-length value '#{max_length_val}'"
       end
     end
+    if definition.key? 'shards-per-node'
+      shards_per_node_val = definition['shards-per-node']
+      unless shards_per_node_val.to_i.to_s == shards_per_node_val
+        raise ArgumentError, "Invalid shards-per-node value '#{shards_per_node_val}'"
+      end
+    end
   end
 
   def munge_definition(definition)
@@ -113,6 +119,9 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     end
     if definition.key? 'max-length'
       definition['max-length'] = definition['max-length'].to_i
+    end
+    if definition.key? 'shards-per-node'
+      definition['shards-per-node'] = definition['shards-per-node'].to_i
     end
     definition
   end

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -144,4 +144,18 @@ describe Puppet::Type.type(:rabbitmq_policy) do
       @policy[:definition] = definition
     }.to raise_error(Puppet::Error, /Invalid max-length value.*future/)
   end
+
+  it 'should accept and convert the shards-per-node value' do
+    definition = {'shards-per-node' => '1800000'}
+    @policy[:definition] = definition
+    @policy[:definition]['shards-per-node'].should be_a(Fixnum)
+    @policy[:definition]['shards-per-node'].should == 1800000
+  end
+
+  it 'should not accept non-numeric shards-per-node value' do
+    definition = {'shards-per-node' => 'future'}
+    expect {
+      @policy[:definition] = definition
+    }.to raise_error(Puppet::Error, /Invalid shards-per-node value.*future/)
+  end
 end


### PR DESCRIPTION
Change `rabbitmq_policy` type to pass the policy definition value `shards-per-node` as an integer instead of a string to `rabbitmqctl`, as required by the [rabbitmq-sharding](https://github.com/rabbitmq/rabbitmq-sharding) plugin.