### PR TITLE
Replace nanliu-staging by voxpupuli-staging

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
-    "staging": "git://github.com/nanliu/puppet-staging.git"
+    "staging": "git://github.com/voxpupuli/puppet-staging.git"
     erlang:
       repo: "https://github.com/garethr/garethr-erlang.git"
   symlinks:

--- a/README.md
+++ b/README.md
@@ -649,9 +649,9 @@ For Debian systems:
       ensure => 'latest',
     }
 
-This module also depends on the excellent nanliu/staging module on the Forge:
+This module also depends on the excellent voxpupuli/staging module on the Forge:
 
-    puppet module install nanliu-staging
+    puppet module install voxpupuli-staging
 
 ### Downgrade Issues
 

--- a/metadata.json
+++ b/metadata.json
@@ -50,6 +50,6 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
-    {"name":"nanliu/staging","version_requirement":">=0.3.1 <2.0.0"}
+    {"name":"voxpupuli/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]
 }


### PR DESCRIPTION
voxpupuli is the namespace supported by Puppetlabs community, we should
use this repository instead of the fork.