### PR TITLE
rabbitmqadmin: bring ipv6 support

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -14,10 +14,18 @@ class rabbitmq::install::rabbitmqadmin {
   $default_pass = $rabbitmq::default_pass
   $node_ip_address = $rabbitmq::node_ip_address
 
+  if is_ipv6_address($node_ip_address) {
+    $curl_prefix  = '-k --noproxy -g -6'
+    $sanitized_ip = join(enclose_ipv6(any2array($node_ip_address)), ',')
+  } else {
+    $curl_prefix  = '-k --noproxy'
+    $sanitized_ip = $node_ip_address
+  }
+
   staging::file { 'rabbitmqadmin':
     target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
-    source      => "${protocol}://${default_user}:${default_pass}@${node_ip_address}:${management_port}/cli/rabbitmqadmin",
-    curl_option => "-k --noproxy ${node_ip_address} --retry 30 --retry-delay 6",
+    source      => "${protocol}://${default_user}:${default_pass}@${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
+    curl_option => "${curl_prefix} ${sanitized_ip} --retry 30 --retry-delay 6",
     timeout     => '180',
     wget_option => '--no-proxy',
     require     => [

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -434,14 +434,30 @@ LimitNOFILE=1234
         context 'with service_manage set to true and default user/pass specified' do
           let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2', :node_ip_address => '1.1.1.1' }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with_source("http://foobar:hunter2@1.1.1.1:15672/cli/rabbitmqadmin")
+            should contain_staging__file('rabbitmqadmin').with(
+              :source      => 'http://foobar:hunter2@1.1.1.1:15672/cli/rabbitmqadmin',
+              :curl_option => '-k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
+            )
           end
         end
         context 'with service_manage set to true and management port specified' do
           # note that the 2.x management port is 55672 not 15672
           let(:params) {{ :admin_enable => true, :management_port => '55672', :node_ip_address => '1.1.1.1' }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@1.1.1.1:55672/cli/rabbitmqadmin")
+            should contain_staging__file('rabbitmqadmin').with(
+              :source      => 'http://guest:guest@1.1.1.1:55672/cli/rabbitmqadmin',
+              :curl_option => '-k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
+            )
+          end
+        end
+        context 'with ipv6, service_manage set to true and management port specified' do
+          # note that the 2.x management port is 55672 not 15672
+          let(:params) {{ :admin_enable => true, :management_port => '55672', :node_ip_address => '::1' }}
+          it 'we use the correct URL to rabbitmqadmin' do
+            should contain_staging__file('rabbitmqadmin').with(
+              :source      => 'http://guest:guest@[::1]:55672/cli/rabbitmqadmin',
+              :curl_option => '-k --noproxy -g -6 [::1] --retry 30 --retry-delay 6',
+            )
           end
         end
         context 'with service_manage set to false' do


### PR DESCRIPTION
(1) If node_ip_address is an IPv6, we need to pass specific options to curl
so staging module can work.

When using IPv6, curl needs to be used with specific options, for
example with localhost:
```curl -g -6 [::1]```

(2) Sanitize node_ip_address if IPv6
node_ip_address is used bu rabbitmqadmin.pp and also in config.pp for
rabbitmqenv.config. This parameter should not be given with brackets,
otherwise RabbitMQ won't start.
Though when using curl, we need the add the brackets so this patch makes
sure the brackets are added to node_ip_address if it's an IPv6 so curl
will work correctly.