### PR TITLE
Rabbitmqadmin IPv6 non-working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ Valid values are true or false.
 
 ####`node_ip_address`
 
-The value of NODE_IP_ADDRESS in rabbitmq_env.config
+The value of NODE_IP_ADDRESS in rabbitmq_env.config and of the
+rabbitmq_management server if it is enabled.
 
 ####`package_ensure`
 

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -15,17 +15,17 @@ class rabbitmq::install::rabbitmqadmin {
   $node_ip_address = $rabbitmq::node_ip_address
 
   if is_ipv6_address($node_ip_address) {
-    $curl_prefix  = '-k --noproxy -g -6'
+    $curl_prefix  = '-g -6'
     $sanitized_ip = join(enclose_ipv6(any2array($node_ip_address)), ',')
   } else {
-    $curl_prefix  = '-k --noproxy'
+    $curl_prefix  = ''
     $sanitized_ip = $node_ip_address
   }
 
   staging::file { 'rabbitmqadmin':
     target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     source      => "${protocol}://${default_user}:${default_pass}@${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
-    curl_option => "${curl_prefix} ${sanitized_ip} --retry 30 --retry-delay 6",
+    curl_option => "-k --noproxy ${node_ip_address} ${curl_prefix} --retry 30 --retry-delay 6",
     timeout     => '180',
     wget_option => '--no-proxy',
     require     => [

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -436,7 +436,7 @@ LimitNOFILE=1234
           it 'we use the correct URL to rabbitmqadmin' do
             should contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://foobar:hunter2@1.1.1.1:15672/cli/rabbitmqadmin',
-              :curl_option => '-k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
+              :curl_option => '-k --noproxy 1.1.1.1  --retry 30 --retry-delay 6',
             )
           end
         end
@@ -446,7 +446,7 @@ LimitNOFILE=1234
           it 'we use the correct URL to rabbitmqadmin' do
             should contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://guest:guest@1.1.1.1:55672/cli/rabbitmqadmin',
-              :curl_option => '-k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
+              :curl_option => '-k --noproxy 1.1.1.1  --retry 30 --retry-delay 6',
             )
           end
         end
@@ -456,7 +456,7 @@ LimitNOFILE=1234
           it 'we use the correct URL to rabbitmqadmin' do
             should contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://guest:guest@[::1]:55672/cli/rabbitmqadmin',
-              :curl_option => '-k --noproxy -g -6 [::1] --retry 30 --retry-delay 6',
+              :curl_option => '-k --noproxy ::1 -g -6 --retry 30 --retry-delay 6',
             )
           end
         end

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -98,6 +98,9 @@
 <%- else -%>
       {port, <%= @management_port %>}
 <%- end -%>
+<%- if @node_ip_address -%>
+      ,{ip, "<%= @node_ip_address %>"}
+<%- end -%>
     ]}
   ]}
 <%- end -%>


### PR DESCRIPTION
The support for IPv6 address for `rabbitmqadmin` is non-working leading
to this error:

```
Debug: Exec[/var/lib/rabbitmq/rabbitmqadmin](provider=posix): Executing 'curl -k --noproxy -g -6 [::1] --retry 30 --retry-delay 6 -f -L -o /var/lib/rabbitmq/rabbitmqadmin "https://guest:guest@[::1]:15671/cli/rabbitmqadmin"'
Debug: Executing 'curl -k --noproxy -g -6 [::1] --retry 30 --retry-delay 6 -f -L -o /var/lib/rabbitmq/rabbitmqadmin "https://guest:guest@[::1]:15671/cli/rabbitmqadmin"'
Notice: /Stage[main]/Rabbitmq::Install::Rabbitmqadmin/Staging::File[rabbitmqadmin]/Exec[/var/lib/rabbitmq/rabbitmqadmin]/returns: curl: (3) [globbing] illegal character in range specification at pos 2
Notice: /Stage[main]/Rabbitmq::Install::Rabbitmqadmin/Staging::File[rabbitmqadmin]/Exec[/var/lib/rabbitmq/rabbitmqadmin]/returns: curl: (3) [globbing] illegal character in range specification at pos 22
Error: curl -k --noproxy -g -6 [::1] --retry 30 --retry-delay 6 -f -L -o /var/lib/rabbitmq/rabbitmqadmin "https://guest:guest@[::1]:15671/cli/rabbitmqadmin" returned 3 instead of one of [0]
Error: /Stage[main]/Rabbitmq::Install::Rabbitmqadmin/Staging::File[rabbitmqadmin]/Exec[/var/lib/rabbitmq/rabbitmqadmin]/returns: change from notrun to 0 failed: curl -k --noproxy -g -6 [::1] --retry 30 --retry-delay 6 -f -L -o /var/lib/rabbitmq/rabbit
```

The problem is that the order of the parameters is all mangled in the
wrong places:
 - `--noproxy` takes the `::1` as parameter, not `-g`
 - `-g` : is ignored as it's the parameter of `--noproxy`
 - `--noproxy` takes `::1` as parameter, not `[::1]`

Finally to have the `rabbitmq_management` server listen on the ip
specified in the curl command (the `node_ip_address`), you have to have
the management server listen to it.  I added the necessary bits.
