### PR TITLE
rabbitmq_management block is created twice.

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -69,13 +69,13 @@
     <%= @config_kernel_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
   ]}
 <%- end -%>
-<% if @config_management_variables -%>,
+<%- if @admin_enable or !@config_management_variables.empty? -%>,
   {rabbitmq_management, [
+    <%- if !@config_management_variables.empty? -%>
     <%= @config_management_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
-  ]}
-<%- end -%>
-<%- if @admin_enable -%>,
-  {rabbitmq_management, [
+    <%- end -%>
+<%- if @admin_enable -%>
+<%- if  !@config_management_variables.empty? -%>,<%-end-%>
     {listener, [
 <%- if @ssl && @management_ssl -%>
       {port, <%= @ssl_management_port %>},
@@ -99,6 +99,7 @@
       {port, <%= @management_port %>}
 <%- end -%>
     ]}
+<%- end -%>
   ]}
 <%- end -%>
 <% if @config_stomp -%>,


### PR DESCRIPTION
Following this commit 8f75ff5cfea7945a0d6a4074184a7279a81349d4, if one
use this simple manifest:

```puppet
class { 'rabbitmq':
    admin_enable   => true,
    service_manage => true,
}
```

Then two blocks of

```
{rabbitmq_management, [
]}
```

gets created.

The problem is that only the parameters of the first block is taken into
account.

Furthermore the /first/ block is *always* created.  The template has:

```
+<% if @config_management_variables -%>,
+  {rabbitmq_management, [
+    <%= @config_management_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
+  ]}
+<%- end -%>
```

and config_management_variables is set to `{}` with is not `false`.

This is an attempt to fix this and keep the same behavior.