### PR TITLE
Merge of pull #444 breaks rabbitmq for me.

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -98,7 +98,7 @@
 <%- else -%>
       {port, <%= @management_port %>}
 <%- end -%>
-<%- if @node_ip_address -%>
+<%- if @node_ip_address != 'UNSET' -%>
       ,{ip, "<%= @node_ip_address %>"}
 <%- end -%>
     ]}


### PR DESCRIPTION
Observed with Puppet 3.8.6 on OpenBSD.

When the parameter is not specified, then 'UNSET' will end
up in the rabbitmq.conf preventing it from starting up.

I don't want to specify it, but I use hiera, so I cannot set
the parameter as undef, which would be taken as string.
Setting the parameter to false, will not get past the
validate_string()

because of that, update the template to check if node_ip_address != 'UNSET'
and only then add it to the resulting file