### PR TITLE
puppet-staging is not yet published

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
-    "staging": "git://github.com/voxpupuli/puppet-staging.git"
+    "staging": "git://github.com/nanliu/puppet-staging.git"
     erlang:
       repo: "https://github.com/garethr/garethr-erlang.git"
   symlinks:

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ For Debian systems:
 
 This module also depends on the excellent puppet/staging module on the Forge:
 
-    puppet module install puppet-staging
+    puppet module install nanliu-staging
 
 ### Downgrade Issues
 

--- a/metadata.json
+++ b/metadata.json
@@ -50,6 +50,6 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
-    {"name":"puppet/staging","version_requirement":">=0.3.1 <2.0.0"}
+    {"name":"nanliu/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,7 +20,7 @@ RSpec.configure do |c|
       if fact('osfamily') == 'Debian'
         shell('puppet module install puppetlabs-apt', { :acceptable_exit_codes => [0,1] })
       end
-      shell('puppet module install puppet-staging', { :acceptable_exit_codes => [0,1] })
+      shell('puppet module install nanliu-staging', { :acceptable_exit_codes => [0,1] })
       if fact('osfamily') == 'RedHat'
         shell('puppet module install garethr-erlang', { :acceptable_exit_codes => [0,1] })
       end


### PR DESCRIPTION
1.0.4 was tagged a while ago but never pushed to their namespace. This
needs to be nanliu until it is pushed to the forge.