### PR TITLE
Fix an issue when $node_ip_address is 'UNSET'.

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -4,8 +4,7 @@ class rabbitmq::install::rabbitmqadmin {
   if($rabbitmq::ssl and $rabbitmq::management_ssl) {
     $management_port = $rabbitmq::ssl_management_port
     $protocol        = 'https'
-  }
-  else {
+  } else {
     $management_port = $rabbitmq::management_port
     $protocol        = 'http'
   }
@@ -14,7 +13,10 @@ class rabbitmq::install::rabbitmqadmin {
   $default_pass = $rabbitmq::default_pass
   $node_ip_address = $rabbitmq::node_ip_address
 
-  if is_ipv6_address($node_ip_address) {
+  if $rabbitmq::node_ip_address == 'UNSET' {
+    # Pull from localhost if we don't have an explicit bind address
+    $sanitized_ip = '127.0.0.1'
+  } elsif is_ipv6_address($node_ip_address) {
     $curl_prefix  = '-g -6'
     $sanitized_ip = join(enclose_ipv6(any2array($node_ip_address)), ',')
   } else {

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -17,17 +17,17 @@ class rabbitmq::install::rabbitmqadmin {
     # Pull from localhost if we don't have an explicit bind address
     $sanitized_ip = '127.0.0.1'
   } elsif is_ipv6_address($node_ip_address) {
-    $curl_prefix  = '-g -6'
+    $curl_prefix  = "--noproxy ${node_ip_address} -g -6"
     $sanitized_ip = join(enclose_ipv6(any2array($node_ip_address)), ',')
   } else {
-    $curl_prefix  = ''
+    $curl_prefix  = "--noproxy ${node_ip_address}"
     $sanitized_ip = $node_ip_address
   }
 
   staging::file { 'rabbitmqadmin':
     target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     source      => "${protocol}://${default_user}:${default_pass}@${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
-    curl_option => "-k --noproxy ${node_ip_address} ${curl_prefix} --retry 30 --retry-delay 6",
+    curl_option => "-k ${curl_prefix} --retry 30 --retry-delay 6",
     timeout     => '180',
     wget_option => '--no-proxy',
     require     => [

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -15,6 +15,7 @@ class rabbitmq::install::rabbitmqadmin {
 
   if $rabbitmq::node_ip_address == 'UNSET' {
     # Pull from localhost if we don't have an explicit bind address
+    $curl_prefix = ''
     $sanitized_ip = '127.0.0.1'
   } elsif is_ipv6_address($node_ip_address) {
     $curl_prefix  = "--noproxy ${node_ip_address} -g -6"

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -448,7 +448,7 @@ LimitNOFILE=1234
           it 'we use the correct URL to rabbitmqadmin' do
             should contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://foobar:hunter2@127.0.0.1:15672/cli/rabbitmqadmin',
-              :curl_option => '-k --noproxy 127.0.0.1  --retry 30 --retry-delay 6',
+              :curl_option => '-k  --retry 30 --retry-delay 6',
             )
           end
         end
@@ -457,7 +457,7 @@ LimitNOFILE=1234
           it 'we use the correct URL to rabbitmqadmin' do
             should contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://foobar:hunter2@1.1.1.1:15672/cli/rabbitmqadmin',
-              :curl_option => '-k --noproxy 1.1.1.1  --retry 30 --retry-delay 6',
+              :curl_option => '-k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
             )
           end
         end
@@ -467,7 +467,7 @@ LimitNOFILE=1234
           it 'we use the correct URL to rabbitmqadmin' do
             should contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://guest:guest@1.1.1.1:55672/cli/rabbitmqadmin',
-              :curl_option => '-k --noproxy 1.1.1.1  --retry 30 --retry-delay 6',
+              :curl_option => '-k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
             )
           end
         end

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -431,7 +431,7 @@ LimitNOFILE=1234
             should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@1.1.1.1:15672/cli/rabbitmqadmin")
           end
         end
-        context 'with default $node_ip_address (UNSET) and service_manage set to true' do
+        context 'with default $node_ip_address="UNSET" and service_manage set to true' do
           let(:params) {{ :admin_enable => true, :node_ip_address => 'UNSET' }}
           it 'we enable the admin interface by default' do
             should contain_class('rabbitmq::install::rabbitmqadmin')
@@ -442,7 +442,7 @@ LimitNOFILE=1234
             should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@127.0.0.1:15672/cli/rabbitmqadmin")
           end
         end
-        context 'with service_manage set to true, node_ip_address = 'UNSET', and default user/pass specified' do
+        context 'with service_manage set to true, node_ip_address = "UNSET", and default user/pass specified' do
           let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2', :node_ip_address => 'UNSET' }}
           it 'we use the correct URL to rabbitmqadmin' do
             should contain_staging__file('rabbitmqadmin').with(

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -431,6 +431,26 @@ LimitNOFILE=1234
             should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@1.1.1.1:15672/cli/rabbitmqadmin")
           end
         end
+        context 'with default $node_ip_address (UNSET) and service_manage set to true' do
+          let(:params) {{ :admin_enable => true, :node_ip_address => 'UNSET' }}
+          it 'we enable the admin interface by default' do
+            should contain_class('rabbitmq::install::rabbitmqadmin')
+            should contain_rabbitmq_plugin('rabbitmq_management').with(
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            )
+            should contain_staging__file('rabbitmqadmin').with_source("http://guest:guest@127.0.0.1:15672/cli/rabbitmqadmin")
+          end
+        end
+        context 'with service_manage set to true, node_ip_address = 'UNSET', and default user/pass specified' do
+          let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2', :node_ip_address => 'UNSET' }}
+          it 'we use the correct URL to rabbitmqadmin' do
+            should contain_staging__file('rabbitmqadmin').with(
+              :source      => 'http://foobar:hunter2@127.0.0.1:15672/cli/rabbitmqadmin',
+              :curl_option => '-k --noproxy 127.0.0.1  --retry 30 --retry-delay 6',
+            )
+          end
+        end
         context 'with service_manage set to true and default user/pass specified' do
           let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2', :node_ip_address => '1.1.1.1' }}
           it 'we use the correct URL to rabbitmqadmin' do


### PR DESCRIPTION
Fix an issue when $node_ip_address is 'UNSET'. Also, make curly-braces for conditionals consistent (and follow the style that I believe is used in puppet style guide).

See https://tickets.puppetlabs.com/browse/MODULES-3098  and 
https://github.com/puppetlabs/puppetlabs-rabbitmq/commit/33dfa95535910424974734f195466d5a804474f9

I did some basic testing, but should be tested some more for corner cases.

Also note that is_ipv6_address was introduced 2 months ago, so will cause problems for anyone with an older stdlib; if we wanted a simpler version, here's a patch against the commit above that I think will also work.

[rabbitmqadmin.pp.patch.txt](https://github.com/puppetlabs/puppetlabs-rabbitmq/files/178400/rabbitmqadmin.pp.patch.txt)
 stdlib. 