### PR TITLE
Properly inherit config_management_variables from params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,7 +68,7 @@ class rabbitmq(
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
-  $config_management_variables = $rabbitmq::config_management_variables,
+  $config_management_variables = $rabbitmq::params::config_management_variables,
   $auth_backends              = $rabbitmq::params::auth_backends,
   $key_content                = undef,
 ) inherits rabbitmq::params {


### PR DESCRIPTION
Missing ::params for the $config_management_variables variable within init.pp.