### PR TITLE
Add handshake_timeout option to rabbitmq config

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ Set rabbitmq file ulimit. Defaults to 16384. Only available on systems with
 Set the heartbeat timeout interval, default is unset which uses the builtin server
 defaultsof 60 seconds. Setting this to `0` will disable heartbeats.
 
+####`handshake_timeout`
+
+Set the connection handshake timeout, maximum time for AMQP handshake, in milliseconds.
+Default is unset which uses the builtin server defaults of 10 seconds.
+
 ####`key_content`
 
 Uses content method for Debian OS family. Should be a template for apt::source

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,6 +28,7 @@ class rabbitmq::config {
   $port                       = $rabbitmq::port
   $tcp_keepalive              = $rabbitmq::tcp_keepalive
   $heartbeat                  = $rabbitmq::heartbeat
+  $handshake_timeout          = $rabbitmq::handshake_timeout
   $service_name               = $rabbitmq::service_name
   $ssl                        = $rabbitmq::ssl
   $ssl_only                   = $rabbitmq::ssl_only

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class rabbitmq(
   $port                       = $rabbitmq::params::port,
   $tcp_keepalive              = $rabbitmq::params::tcp_keepalive,
   $heartbeat                  = $rabbitmq::params::heartbeat,
+  $handshake_timeout          = $rabbitmq::params::handshake_timeout,
   $service_ensure             = $rabbitmq::params::service_ensure,
   $service_manage             = $rabbitmq::params::service_manage,
   $service_name               = $rabbitmq::params::service_name,
@@ -150,6 +151,10 @@ class rabbitmq(
 
   if $heartbeat {
     validate_integer($heartbeat)
+  }
+
+  if $handshake_timeout {
+    validate_integer($handshake_timeout)
   }
 
   if $auth_backends {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -93,6 +93,7 @@ class rabbitmq::params {
   $port                        = '5672'
   $tcp_keepalive               = false
   $heartbeat                   = undef
+  $handshake_timeout           = undef
   $ssl                         = false
   $ssl_only                    = false
   $ssl_cacert                  = 'UNSET'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1228,6 +1228,23 @@ LimitNOFILE=1234
         end
       end
 
+      describe 'handshake_timeout option' do
+        let(:params) {{ :handshake_timeout => 10000 }}
+        it 'should set handshake_timeout opt in config file' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{handshake_timeout, 10000\}/)
+        end
+      end
+
+      describe 'non-integer handshake_timeout option' do
+        let(:params) {{ :handshake_timeout => 'str10' }}
+        it 'should raise a validation error' do
+          expect {
+            should contain_file('rabbitmq.config')
+          }.to raise_error(Puppet::Error, /Expected first argument to be an Integer/)
+        end
+      end
+
       context 'delete_guest_user' do
         describe 'should do nothing by default' do
           it { should_not contain_rabbitmq_user('guest') }

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -8,6 +8,9 @@
 <%- if @heartbeat -%>
     {heartbeat, <%=@heartbeat%>},
 <% end -%>
+<%- if @handshake_timeout -%>
+    {handshake_timeout, <%= @handshake_timeout %>},
+<% end -%>
 <% if @auth_backends -%>
     {auth_backends, [<%= @auth_backends.map { |v| "#{v}" }.join(', ') %>]},
 <% elsif @ldap_auth -%>


### PR DESCRIPTION
Bring in handshake_timeout option to rabbitmq config (10 seconds by
default). When clients run in heavily constrained environments,
it may be necessary to increase the timeout.