### PR TITLE
Add additional config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ class { 'rabbitmq':
 }
 ```
 
+### Additional Variables Configurable in rabbitmq.config
+To change Additional Config Variables in rabbitmq.config, use the parameter
+`config_additional_variables` e.g.:
+
+```puppet
+class { 'rabbitmq':
+  config_additional_variables => {
+    'autocluster' => '[{consul_service, "rabbit"},{cluster_name, "rabbit"}]',
+    'foo' => '[{bar, "baz"}]'
+  }
+}
+```
+This will result in the following config appended to the config file:
+```
+% Additional config
+  {autocluster, [{consul_service, "rabbit"},{cluster_name, "rabbit"}]},
+  {foo, [{bar, "baz"}]}
+```
+(This is required for the [autocluster plugin](https://github.com/aweber/rabbitmq-autocluster)
+
 ### Clustering
 To use RabbitMQ clustering facilities, use the rabbitmq parameters
 `config_cluster`, `cluster_nodes`, and `cluster_node_type`, e.g.:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,6 +56,7 @@ class rabbitmq::config {
   $config_variables           = $rabbitmq::config_variables
   $config_kernel_variables    = $rabbitmq::config_kernel_variables
   $config_management_variables = $rabbitmq::config_management_variables
+  $config_additional_variables = $rabbitmq::config_additional_variables
   $auth_backends              = $rabbitmq::auth_backends
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $file_limit                 = $rabbitmq::file_limit

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,7 @@ class rabbitmq(
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
   $config_management_variables = $rabbitmq::params::config_management_variables,
+  $config_additional_variables = $rabbitmq::params::config_additional_variables,
   $auth_backends              = $rabbitmq::params::auth_backends,
   $key_content                = undef,
 ) inherits rabbitmq::params {
@@ -147,6 +148,7 @@ class rabbitmq(
   validate_hash($config_variables)
   validate_hash($config_kernel_variables)
   validate_hash($config_management_variables)
+  validate_hash($config_additional_variables)
 
   if $heartbeat {
     validate_integer($heartbeat)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,6 +125,7 @@ class rabbitmq::params {
   $config_variables            = {}
   $config_kernel_variables     = {}
   $config_management_variables = {}
+  $config_additional_variables = {}
   $auth_backends               = undef
   $file_limit                  = '16384'
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1205,6 +1205,16 @@ LimitNOFILE=1234
         end
       end
 
+      describe 'config_additional_variables' do
+        let(:params) {{ :config_additional_variables => {
+            'autocluster'     => '[{consul_service, "rabbit"},{cluster_name, "rabbit"}]',
+        }}}
+        it 'should set config variables' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{autocluster, \[\{consul_service, "rabbit"\},\{cluster_name, "rabbit"\}\]\}/)
+        end
+      end
+
       describe 'tcp_keepalive enabled' do
         let(:params) {{ :tcp_keepalive => true }}
         it 'should set tcp_listen_options keepalive true' do

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -141,5 +141,11 @@
       <%= @config_shovel_statics.sort.map{|k,v| "{#{k},[#{v}]}"}.join(",\n      ") %>
     ]}]}
 <%- end -%>
+<%- if @config_additional_variables and not @config_additional_variables.empty? -%>,
+% Additional config
+<%- @config_additional_variables.keys.sort.each do |key| -%>
+  {<%= key %>, <%= @config_additional_variables[key] %>}<%- if key != @config_additional_variables.keys.sort.last %>,<% end %>
+<%- end -%>
+<%- end -%>
 ].
 % EOF


### PR DESCRIPTION
This allows us to add additional config variables to the end of the rabbitmq.conf file - this is useful for adding generic plugin config, for example.