### PR TITLE
Bugfix rabbitmq_parameter type check for add-forward-headers.  Requires boolean.

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -56,7 +56,7 @@ Puppet::Type.newtype(:rabbitmq_parameter) do
       raise ArgumentError, "Invalid value"
     end
     value.each do |k,v|
-      unless [String].include?(v.class)
+      unless [String, TrueClass, FalseClass].include?(v.class)
         raise ArgumentError, "Invalid value"
       end
     end


### PR DESCRIPTION
When attempting to specify add-forward-headers to a rabbitmq shovel parameter, the rabbitmq_parameter type limits input to strings, but the rabbitmqctl command requires a boolean type.

Without the patch, add-forward-headers raises the ArgumentError when a boolean is specified:
```Error: Failed to apply catalog: Parameter value failed on Rabbitmq_parameter[testhost@testvhost]: Invalid value at shovel_queue.pp:27```

Without the patch, add-forward-headers as a string type raises an error in rabbitmqctl:
```
Error: Validation failed

add-forward-headers should be boolean, actually was <<"false">>
```

This PR allows boolean types to be used in the value attribute when using the rabbitmq_parameter resource.