### PR TITLE
Unbreak package installation on OpenBSD.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,6 +188,10 @@ class rabbitmq(
         $base_version   = regsubst($version,'^(.*)-\d$','\1')
         $real_package_source = "http://www.rabbitmq.com/releases/rabbitmq-server/v${base_version}/rabbitmq-server-${version}.noarch.rpm"
       }
+      'OpenBSD': {
+        # We just use the default OpenBSD package from a mirror
+        $real_package_source = undef
+      }
       default: { # Archlinux and Debian
         $real_package_source = ''
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class rabbitmq::params {
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq'
       $service_name     = 'rabbitmq'
-      $package_provider = undef
+      $package_provider = 'openbsd'
       $version          = '3.4.2'
       $rabbitmq_user    = '_rabbitmq'
       $rabbitmq_group   = '_rabbitmq'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1348,6 +1348,17 @@ LimitNOFILE=1234
     end
   end
 
+  context "on OpenBSD" do
+    with_openbsd_facts
+    it 'installs the rabbitmq package' do
+      should contain_package('rabbitmq-server').with(
+        'ensure'   => 'installed',
+        'name'     => 'rabbitmq',
+        'provider' => 'openbsd'
+      )
+    end
+  end
+
   describe 'repo management on Debian' do
     with_debian_facts
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -9,6 +9,19 @@ def with_debian_facts
   end
 end
 
+def with_openbsd_facts
+  # operatingsystemmajrelease is too broad
+  # operatingsystemrelease may contain X.X-current
+  # or other prefixes
+  let :facts do
+    {
+      :osfamily                  => 'OpenBSD',
+      :kernelversion             => '5.9',
+      :staging_http_get          => ''
+    }
+  end
+end
+
 def with_redhat_facts
   let :facts do
     {


### PR DESCRIPTION
OpenBSD doesn't need to set a source for the package installation.
Add some spec tests for this particular OpenBSD case.

This makes it work for me as expected/intended.

