### PR TITLE
(#3295) Give an opportunity to suppress ssl_stomp warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class rabbitmq(
     validate_re($ssl_management_port, '\d+')
   }
   if ! is_integer($ssl_stomp_port) {
-    validate_re($ssl_stomp_port, '\d+')
+    validate_bool($ssl_stomp_port)
   }
   validate_bool($stomp_ensure)
   validate_bool($stomp_ssl_only)


### PR DESCRIPTION
Validate ssl_stomp_port as boolean if it is not set as integer.
It allows to set it as 'false' in case when there is disabled
ssl and configured non-ssl stomp, which will suppress whe warning
about '$ssl_stomp_port requires that $ssl => true'.