### PR TITLE
Don't show new user password changes on noop runs

### DIFF
--- a/lib/puppet/type/rabbitmq_user.rb
+++ b/lib/puppet/type/rabbitmq_user.rb
@@ -29,6 +29,9 @@ Puppet::Type.newtype(:rabbitmq_user) do
     def change_to_s(current, desired)
       "password has been changed"
     end
+    def should_to_s(newvalue = @should)
+      '<new password>'
+    end
   end
 
   newproperty(:admin) do


### PR DESCRIPTION
Change the log output to not include the user's password, as many places don't want their passwords in logs. This was already done for actual runs, but not --noop runs.

Output before was:
```
Rabbitmq_user[demo]/password: current_value , should be SecretPassword (noop)
```

Output now is:
```
Rabbitmq_user[demo]/password: current_value , should be <new password> (noop)
```

I don't have a corresponding spec for this, unfortunately. I played with rspec-puppet for a while but couldn't find a way to trap the output generated by puppet itself in order to assert against it. I would appreciate help in doing so.