### PR TITLE
MODULES 3336- variables allowing control of automatic restart with RedHat

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,12 @@ Location of RabbitMQ plugins.
 
 The RabbitMQ port.
 
+####`restart_param`
+
+Only available on systems with `$::osfamily == 'RedHat'`. Systemd variable
+that specifies application's restart tendency. Default is 'no'.
+Use with start_limit_interval and start_limit_burst to control restart attempts.
+
 ####`service_ensure`
 
 The state of the service.
@@ -421,6 +427,14 @@ Support only a given list of SSL ciphers. Example: `['dhe_rsa,aes_256_cbc,sha','
 Supported ciphers in your install can be listed with:
  rabbitmqctl eval 'ssl:cipher_suites().'
 Functionality can be tested with cipherscan or similar tool: https://github.com/jvehent/cipherscan.git
+
+####`start_limit_burst`
+
+Only available on systems with `$::osfamily == 'RedHat'`. Systemd variable, default '3'.
+
+####`start_limit_interval`
+
+Only available on systems with `$::osfamily == 'RedHat'`. Systemd variable that, default '60s'
 
 ####`stomp_port`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -59,6 +59,9 @@ class rabbitmq::config {
   $auth_backends              = $rabbitmq::auth_backends
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $file_limit                 = $rabbitmq::file_limit
+  $restart_param              = $rabbitmq::restart_param
+  $start_limit_interval       = $rabbitmq::start_limit_interval
+  $start_limit_burst          = $rabbitmq::start_limit_burst
   $default_env_variables      =  {
     'NODE_PORT'        => $port,
     'NODE_IP_ADDRESS'  => $node_ip_address

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,9 @@ class rabbitmq(
   $wipe_db_on_cookie_change   = $rabbitmq::params::wipe_db_on_cookie_change,
   $cluster_partition_handling = $rabbitmq::params::cluster_partition_handling,
   $file_limit                 = $rabbitmq::params::file_limit,
+  $restart_param              = $rabbitmq::params::restart_param,
+  $start_limit_interval       = $rabbitmq::params::start_limit_interval,
+  $start_limit_burst          = $rabbitmq::params::start_limit_burst,
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
@@ -108,6 +111,9 @@ class rabbitmq(
   if ! is_integer($stomp_port) {
     validate_re($stomp_port, '\d+')
   }
+  validate_string($restart_param)
+  validate_string($start_limit_interval)
+  validate_string($start_limit_burst)
   validate_bool($wipe_db_on_cookie_change)
   validate_bool($tcp_keepalive)
   # using sprintf for conversion to string, because "${file_limit}" doesn't

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -127,4 +127,7 @@ class rabbitmq::params {
   $config_management_variables = {}
   $auth_backends               = undef
   $file_limit                  = '16384'
+  $start_limit_interval        = '60s'
+  $start_limit_burst           = '3'
+  $restart_param               = 'no'
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -351,6 +351,9 @@ rabbitmq hard nofile 1234
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=unlimited
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
@@ -364,6 +367,9 @@ LimitNOFILE=unlimited
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=infinity
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
@@ -377,6 +383,9 @@ LimitNOFILE=infinity
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=-1
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
@@ -390,9 +399,30 @@ LimitNOFILE=-1
         'notify'  => 'Exec[rabbitmq-systemd-reload]',
         'content' => '[Service]
 LimitNOFILE=1234
+Restart=no
+StartLimitInterval=60s
+StartLimitBurst=3
 '
       ) }
     end
+   context 'with restart_params=on-failure' do
+      let(:params) {{ :file_limit => '1234',
+                      :restart_param => 'on-failure',
+                      :start_limit_interval => '30s',
+                      :start_limit_burst => '5' }}
+      it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
+        'owner'   => '0',
+        'group'   => '0',
+        'mode'    => '0644',
+        'notify'  => 'Exec[rabbitmq-systemd-reload]',
+        'content' => '[Service]
+LimitNOFILE=1234
+Restart=on-failure
+StartLimitInterval=30s
+StartLimitBurst=5
+'
+     )}
+   end
   end
 
   ['Debian', 'RedHat', 'SUSE', 'Archlinux'].each do |distro|

--- a/templates/rabbitmq-server.service.d/limits.conf
+++ b/templates/rabbitmq-server.service.d/limits.conf
@@ -1,2 +1,5 @@
 [Service]
 LimitNOFILE=<%= @file_limit %>
+Restart=<%= @restart_param %>
+StartLimitInterval=<%= @start_limit_interval %>
+StartLimitBurst=<%= @start_limit_burst %>


### PR DESCRIPTION
Making use of the already defined rabbitmq-server.service.d/limits.conf to include three more service variables controlling automated restarting of the rabbitmq-server service. Allows control of under what circumstances auto-restarts occur, how many times restarts are attempted under what circumstances.
