### PR TITLE
Improve robustness of rabbitmq_nodename

### DIFF
--- a/lib/facter/rabbitmq_nodename.rb
+++ b/lib/facter/rabbitmq_nodename.rb
@@ -2,7 +2,7 @@ Facter.add(:rabbitmq_nodename) do
   setcode do
     if Facter::Core::Execution.which('rabbitmqctl')
       rabbitmq_nodename = Facter::Core::Execution.execute('rabbitmqctl status 2>&1')
-      %r{^Status of node ([\w\.]+@[\w\.]+) \.+$}.match(rabbitmq_nodename)[1]
+      %r{^Status of node '?([\w\.]+@[\w\.\-]+)'? \.+$}.match(rabbitmq_nodename)[1]
     end
   end
 end

--- a/spec/unit/rabbitmq_nodename_spec.rb
+++ b/spec/unit/rabbitmq_nodename_spec.rb
@@ -15,5 +15,25 @@ describe Facter::Util::Fact do
         expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit1')
       }
     end
+
+    context 'with dashes in hostname' do
+      before :each do
+        Facter::Core::Execution.stubs(:which).with('rabbitmqctl').returns(true)
+        Facter::Core::Execution.stubs(:execute).with('rabbitmqctl status 2>&1').returns('Status of node monty@rabbit-1 ...')
+      end
+      it {
+        expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
+      }
+    end
+
+    context 'with quotes around node name' do
+      before :each do
+        Facter::Core::Execution.stubs(:which).with('rabbitmqctl').returns(true)
+        Facter::Core::Execution.stubs(:execute).with('rabbitmqctl status 2>&1').returns('Status of node \'monty@rabbit-1\' ...')
+      end
+      it {
+        expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
+      }
+    end
   end
 end


### PR DESCRIPTION
With certain platforms, the nodename is quoted resulting in a NilClass
error.  In addition, the regex does not properly match if a nodename
has dashes.  This commit resolves these issues.