### PR TITLE
add service provider to service and params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class rabbitmq::params {
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
       $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
+      $service_provider = undef
     }
     'Debian': {
       $package_ensure   = 'installed'
@@ -26,6 +27,7 @@ class rabbitmq::params {
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
       $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
+      $service_provider = undef
     }
     'OpenBSD': {
       $package_ensure   = 'installed'
@@ -37,6 +39,7 @@ class rabbitmq::params {
       $rabbitmq_group   = '_rabbitmq'
       $rabbitmq_home    = '/var/rabbitmq'
       $plugin_dir       = '/usr/local/lib/rabbitmq/plugins'
+      $service_provider = undef
     }
     'RedHat': {
       $package_ensure   = 'installed'
@@ -48,6 +51,7 @@ class rabbitmq::params {
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
       $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
+      $service_provider = 'redhat'
     }
     'SUSE': {
       $package_ensure   = 'installed'
@@ -59,6 +63,7 @@ class rabbitmq::params {
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
       $plugin_dir       = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version}/plugins"
+      $service_provider = undef
     }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")
@@ -69,7 +74,7 @@ class rabbitmq::params {
   $admin_enable                = true
   $management_port             = '15672'
   $management_ssl              = true
-  $package_apt_pin             = ''
+  $package_apt_pin             = '' # lint:ignore:empty_string_assignment
   $package_gpg_key             = 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc'
   $repos_ensure                = true
   $manage_repos                = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,9 +11,10 @@
 # Sample Usage:
 #
 class rabbitmq::service(
-  $service_ensure = $rabbitmq::service_ensure,
-  $service_manage = $rabbitmq::service_manage,
-  $service_name   = $rabbitmq::service_name,
+  $service_ensure   = $rabbitmq::service_ensure,
+  $service_manage   = $rabbitmq::service_manage,
+  $service_name     = $rabbitmq::service_name,
+  $service_provider = $rabbitmq::params::service_provider,
 ) inherits rabbitmq {
 
   validate_re($service_ensure, '^(running|stopped)$')
@@ -34,6 +35,7 @@ class rabbitmq::service(
       hasstatus  => true,
       hasrestart => true,
       name       => $service_name,
+      provider   => $service_provider,
     }
   }
 

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -187,6 +187,10 @@ describe 'rabbitmq' do
       should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
     end
 
+    it 'should set service provider to redhat' do
+      should contain_service('rabbitmq-server').with_provider('redhat')
+    end
+
     context 'with file_limit => \'unlimited\'' do
       let(:params) {{ :file_limit => 'unlimited' }}
       it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(


### PR DESCRIPTION
We have noticed the rabbitmq-server service on rhel7 systems always changes. Setting the provider to redhat resolves the issue.

I added the service_provider param to all OS cases but I don't know what the proper value should be. I'm happy to fill in additional values and add spec tests for coverage.