### PR TITLE
move rabbitmq signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ be changed to latest.
 
 RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat
 OS family, or a file name for RedHat OS family.
-Set to http://www.rabbitmq.com/rabbitmq-signing-key-public.asc by default.
+Set to http://www.rabbitmq.com/rabbitmq-release-signing-key.asc by default.
 Note, that `key_content`, if specified, would override this parameter for Debian OS family.
 
 ####`package_name`

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,7 +70,7 @@ class rabbitmq::params {
   $management_port             = '15672'
   $management_ssl              = true
   $package_apt_pin             = ''
-  $package_gpg_key             = 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc'
+  $package_gpg_key             = 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc'
   $repos_ensure                = true
   $manage_repos                = undef
   $service_ensure              = 'running'

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,8 +6,8 @@ class rabbitmq::repo::apt(
   $release      = 'testing',
   $repos        = 'main',
   $include_src  = false,
-  $key          = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
-  $key_source   = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+  $key          = '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
+  $key_source   = 'http://www.rabbitmq.com/rabbitmq-release-signing-key.asc',
   $key_content  = undef,
   $architecture = undef,
   ) {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -184,7 +184,7 @@ describe 'rabbitmq' do
     with_redhat_facts
     it 'includes rabbitmq::repo::rhel' do
       should contain_class('rabbitmq::repo::rhel')
-      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
 
     context 'with file_limit => \'unlimited\'' do
@@ -259,7 +259,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does not import repo public key when repos_ensure is false' do
       should contain_class('rabbitmq::repo::rhel')
-      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -268,7 +268,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does import repo public key when repos_ensure is true' do
       should contain_class('rabbitmq::repo::rhel')
-      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -277,7 +277,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does not import repo public key when manage_repos is false' do
       should_not contain_class('rabbitmq::repo::rhel')
-      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -286,7 +286,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does import repo public key when manage_repos is true' do
       should contain_class('rabbitmq::repo::rhel')
-      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -295,7 +295,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does not import repo public key when manage_repos is false and repos_ensure is true' do
       should_not contain_class('rabbitmq::repo::rhel')
-      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -304,7 +304,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does import repo public key when manage_repos is true and repos_ensure is true' do
       should contain_class('rabbitmq::repo::rhel')
-      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -313,7 +313,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does not import repo public key when manage_repos is false and repos_ensure is false' do
       should_not contain_class('rabbitmq::repo::rhel')
-      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -322,7 +322,7 @@ rabbitmq hard nofile 1234
     with_redhat_facts
     it 'does not import repo public key when manage_repos is true and repos_ensure is false' do
       should contain_class('rabbitmq::repo::rhel')
-      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc')
+      should_not contain_exec('rpm --import https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end
 
@@ -1371,7 +1371,7 @@ LimitNOFILE=1234
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
+          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
         ) }
       end
     end
@@ -1385,7 +1385,7 @@ LimitNOFILE=1234
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56'
+          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(
@@ -1419,7 +1419,7 @@ LimitNOFILE=1234
     describe "repo management on #{distro}" do
       describe 'imports the key' do
         let(:facts) { osfacts }
-        let(:params) {{ :package_gpg_key => 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc' }}
+        let(:params) {{ :package_gpg_key => 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc' }}
 
         it { should contain_exec("rpm --import #{params[:package_gpg_key]}").with(
           'path' => ['/bin','/usr/bin','/sbin','/usr/sbin']


### PR DESCRIPTION
Signing key moved to https://www.rabbitmq.com/rabbitmq-release-signing-key.asc

This patch aims to update the module.