### PR TITLE
Add support for configuration of loopback_users

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class rabbitmq(
   $ldap_port                  = $rabbitmq::params::ldap_port,
   $ldap_log                   = $rabbitmq::params::ldap_log,
   $ldap_config_variables      = $rabbitmq::params::ldap_config_variables,
+  $loopback_users             = $rabbitmq::params::loopback_users,
   $stomp_port                 = $rabbitmq::params::stomp_port,
   $stomp_ssl_only             = $rabbitmq::params::stomp_ssl_only,
   $version                    = $rabbitmq::params::version,
@@ -133,6 +134,11 @@ class rabbitmq(
   validate_bool($ldap_use_ssl)
   validate_re($ldap_port, '\d+')
   validate_bool($ldap_log)
+
+  if $loopback_users {
+    validate_array($loopback_users)
+  }
+
   validate_hash($environment_variables)
   validate_hash($config_variables)
   validate_hash($config_kernel_variables)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -112,6 +112,7 @@ class rabbitmq::params {
   $ldap_port                  = '389'
   $ldap_log                   = false
   $ldap_config_variables      = {}
+  $loopback_users             = undef
   $stomp_port                 = '6163'
   $stomp_ssl_only             = false
   $wipe_db_on_cookie_change   = false

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -8,6 +8,9 @@
 <% if @ldap_auth -%>
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
 <% end -%>
+<% if @loopback_users and @loopback_users.size > 0 -%>
+    {loopback_users, [<%= @loopback_users.map { |u| "'#{u}'" }.join(', ') %>]},
+<% end -%>
 <% if @config_cluster -%>
     {cluster_nodes, {[<%= @cluster_nodes.map { |n| "\'rabbit@#{n}\'" }.join(', ') %>], <%= @cluster_node_type %>}},
     {cluster_partition_handling, <%= @cluster_partition_handling %>},


### PR DESCRIPTION
Makes it possible to configure the list of loopback_users. This is
particularily useful to allow access from all interfaces to the
'guest' user which is limited to 'localhost' by default [1].

1. https://www.rabbitmq.com/access-control.html