### PR TITLE
Add tcp parameters and stats collect config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,9 @@ class rabbitmq::config {
   $rabbitmq_home              = $rabbitmq::rabbitmq_home
   $port                       = $rabbitmq::port
   $tcp_keepalive              = $rabbitmq::tcp_keepalive
+  $tcp_backlog                = $rabbitmq::tcp_backlog
+  $tcp_sndbuf                 = $rabbitmq::tcp_sndbuf
+  $tcp_recbuf                 = $rabbitmq::tcp_recbuf
   $heartbeat                  = $rabbitmq::heartbeat
   $service_name               = $rabbitmq::service_name
   $ssl                        = $rabbitmq::ssl
@@ -60,6 +63,7 @@ class rabbitmq::config {
   $auth_backends              = $rabbitmq::auth_backends
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $file_limit                 = $rabbitmq::file_limit
+  $collect_statistics_interval = $rabbitmq::collect_statistics_interval
   $default_env_variables      =  {
     'NODE_PORT'        => $port,
     'NODE_IP_ADDRESS'  => $node_ip_address

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,9 @@ class rabbitmq(
   $rabbitmq_home              = $rabbitmq::params::rabbitmq_home,
   $port                       = $rabbitmq::params::port,
   $tcp_keepalive              = $rabbitmq::params::tcp_keepalive,
+  $tcp_backlog                = $rabbitmq::params::tcp_backlog,
+  $tcp_sndbuf                 = $rabbitmq::params::tcp_sndbuf,
+  $tcp_recbuf                 = $rabbitmq::params::tcp_recbuf,
   $heartbeat                  = $rabbitmq::params::heartbeat,
   $service_ensure             = $rabbitmq::params::service_ensure,
   $service_manage             = $rabbitmq::params::service_manage,
@@ -72,6 +75,7 @@ class rabbitmq(
   $config_additional_variables = $rabbitmq::params::config_additional_variables,
   $auth_backends              = $rabbitmq::params::auth_backends,
   $key_content                = undef,
+  $collect_statistics_interval = $rabbitmq::params::collect_statistics_interval,
 ) inherits rabbitmq::params {
 
   validate_bool($admin_enable)
@@ -111,6 +115,16 @@ class rabbitmq(
   }
   validate_bool($wipe_db_on_cookie_change)
   validate_bool($tcp_keepalive)
+  if $tcp_backlog {
+    validate_integer($tcp_backlog)
+  }
+  if $tcp_sndbuf {
+    validate_integer($tcp_sndbuf)
+  }
+  if $tcp_recbuf {
+    validate_integer($tcp_recbuf)
+  }
+
   # using sprintf for conversion to string, because "${file_limit}" doesn't
   # pass lint, despite being nicer
   validate_re(sprintf('%s', $file_limit),
@@ -149,6 +163,10 @@ class rabbitmq(
   validate_hash($config_kernel_variables)
   validate_hash($config_management_variables)
   validate_hash($config_additional_variables)
+
+  if $collect_statistics_interval {
+    validate_integer($collect_statistics_interval)
+  }
 
   if $heartbeat {
     validate_integer($heartbeat)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -94,6 +94,9 @@ class rabbitmq::params {
   $node_ip_address             = 'UNSET'
   $port                        = '5672'
   $tcp_keepalive               = false
+  $tcp_backlog                 = 128
+  $tcp_sndbuf                  = false
+  $tcp_recbuf                  = false
   $heartbeat                   = undef
   $ssl                         = false
   $ssl_only                    = false
@@ -128,4 +131,5 @@ class rabbitmq::params {
   $config_additional_variables = {}
   $auth_backends               = undef
   $file_limit                  = '16384'
+  $collect_statistics_interval = false
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1232,6 +1232,60 @@ LimitNOFILE=1234
         end
       end
 
+      describe 'tcp_backlog with default value' do
+        it 'should set tcp_listen_options backlog to 128' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{backlog,       128\}/)
+        end
+      end
+
+      describe 'tcp_backlog with non-default value' do
+        let(:params) do
+          { :tcp_backlog => 256 }
+        end
+
+        it 'should set tcp_listen_options backlog to 256' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{backlog,       256\}/)
+        end
+      end
+
+      describe 'tcp_sndbuf with default value' do
+        it 'should not set tcp_listen_options sndbuf' do
+          should contain_file('rabbitmq.config') \
+            .without_content(/sndbuf/)
+        end
+      end
+
+      describe 'tcp_sndbuf with non-default value' do
+        let(:params) do
+          { :tcp_sndbuf => 128 }
+        end
+
+        it 'should set tcp_listen_options sndbuf to 128' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{sndbuf,       128\}/)
+        end
+      end
+
+      describe 'tcp_recbuf with default value' do
+        it 'should not set tcp_listen_options recbuf' do
+          should contain_file('rabbitmq.config') \
+            .without_content(/recbuf/)
+        end
+      end
+
+      describe 'tcp_recbuf with non-default value' do
+        let(:params) do
+          { :tcp_recbuf => 128 }
+        end
+
+        it 'should set tcp_listen_options recbuf to 128' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{recbuf,       128\}/)
+        end
+      end
+
       describe 'rabbitmq-heartbeat options' do
         let(:params) {{ :heartbeat => 60 }}
         it 'should set heartbeat paramter in config file' do

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -24,10 +24,21 @@
          <%- end -%>
          {packet,        raw},
          {reuseaddr,     true},
-         {backlog,       128},
+         <%- if @tcp_backlog -%>
+         {backlog,       <%= @tcp_backlog %>},
+         <%- end -%>
+         <%- if @tcp_sndbuf -%>
+         {sndbuf,       <%= @tcp_sndbuf %>},
+         <%- end -%>
+         <%- if @tcp_recbuf -%>
+         {recbuf,       <%= @tcp_recbuf %>},
+         <%- end -%>
          {nodelay,       true},
          {exit_on_close, false}]
     },
+<%- if @collect_statistics_interval -%>
+    {collect_statistics_interval, <%= @collect_statistics_interval %>},
+<%- end -%>
 <%- if @ssl_only -%>
     {tcp_listeners, []},
 <%- elsif @interface != 'UNSET' -%>


### PR DESCRIPTION
MODULES-3570 Rabbitmq config tcp options and collect statistics interval tuning

* Add parameters to tune the rabbitmq tcp options.
* Add collect statistics interval parameter to configure the management plugin
  This paramter can help increase the performance of rabbitmq by reducing load
  on rabbit with stats collections.