### PR TITLE
Add definition validation and munge for ha-sync-batch-size

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -107,7 +107,7 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     end
     if definition.key? 'ha-sync-batch-size'
       ha_sync_batch_size_val = definition['ha-sync-batch-size']
-      unless ha_sync_batch_size_val.to_i.tos == ha_sync_batch_size_val
+      unless ha_sync_batch_size_val.to_i.to_s == ha_sync_batch_size_val
         raise ArgumentErro, "Invalid ha-sync-batch-size value '#{ha_sync_batch_size_val}'"
       end
     end

--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -105,6 +105,12 @@ Puppet::Type.newtype(:rabbitmq_policy) do
         raise ArgumentError, "Invalid shards-per-node value '#{shards_per_node_val}'"
       end
     end
+    if definition.key? 'ha-sync-batch-size'
+      ha_sync_batch_size_val = definition['ha-sync-batch-size']
+      unless ha_sync_batch_size_val.to_i.tos == ha_sync_batch_size_val
+        raise ArgumentErro, "Invalid ha-sync-batch-size value '#{ha_sync_batch_size_val}'"
+      end
+    end
   end
 
   def munge_definition(definition)
@@ -122,6 +128,9 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     end
     if definition.key? 'shards-per-node'
       definition['shards-per-node'] = definition['shards-per-node'].to_i
+    end
+    if definition.key? 'ha-sync-batch-size'
+      definition['ha-sync-batch-size'] = definition['ha-sync-batch-size'].to_i
     end
     definition
   end


### PR DESCRIPTION
With the release of RabbitMQ 3.6 there is an option to set the ha-sync-batch-size.
This option takes an integer >0. This commit adds a validation statement to check
the supplied value is an integer and then converts the string input into an
integer.