### PR TITLE
basic support for multiple routing keys

### DIFF
--- a/lib/puppet/type/rabbitmq_binding.rb
+++ b/lib/puppet/type/rabbitmq_binding.rb
@@ -22,9 +22,21 @@ Puppet::Type.newtype(:rabbitmq_binding) do
     defaultto('queue')
   end
   
-  newparam(:routing_key) do
+  newparam(:routing_key, :array_matching => :all) do
     desc 'binding routing_key'
-    newvalues(/^\S*$/)
+
+    validate do |values|
+      # Unlike what you'd expect from docs on array_matching, a string
+      # isn't forced into list context here.
+      values = [values] unless values.is_a?(Array)
+      values = values.uniq
+      values.each do |value|
+        unless value =~ /^\S*$/
+          raise ArgumentError, "Invalid routing_key '#{value}'"
+        end
+      end
+    end
+
   end
 
   newparam(:arguments) do


### PR DESCRIPTION
This still needs some work (and test coverage), but here's how I was able to get support for multiple routing keys to work in a backwards compatible way. Would appreciate feedback / improvements / guidance on best ways to add test cases for this.

I don't see a way to support removing a binding with one routing key while adding or ensuring another... I think this would have to be done by including the routing key as part of the key of the main hash.

I do get this error on runs, though seems to work in basic cases for ensuring presence / absence, including when new bindings are added. Presumably a data structure issue with resources?

```Error: Could not prefetch rabbitmq_binding provider 'rabbitmqadmin': undefined method `[]' for #<Binding:0x00000002a08a28>
Notice: /Stage[main]/Role::Rabbitmq/Rabbitmq_binding[foo.bar.xyz@foo.bar.xyz.queue@/]/ensure: created
```
