### PR TITLE
(MODULES-3740) Adding missing undocumented rabbitmq tcp_listen_options directive

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -34,6 +34,7 @@
          {recbuf,       <%= @tcp_recbuf %>},
          <%- end -%>
          {nodelay,       true},
+         {linger,        {true, 0}},
          {exit_on_close, false}]
     },
 <%- if @collect_statistics_interval -%>


### PR DESCRIPTION
We've noticed changes in our RabbitMQ infrastructure after upgrading  Puppet module to the latest forge release, tcp_listen_options were added to RabbitMQ configuration template. Unfortunately, one option was missing and it changes significantly on how broker terminates connections after heartbeat has expired - instead of previous behaviour of sending RST,ACK it starts sending FIN,ACKs instead causing libraries that don't have good exception handling or they aren't using publisher confirms options for publishing messages to start losing messages.

Adding this directive as per https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit.app.src as it's listed as default but not documented on RabbitMQ website.

