### PR TITLE
Updated app.pp to address deprecation warnings

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -25,12 +25,12 @@ class rabbitmq::repo::apt(
   }
 
   apt::source { 'rabbitmq':
-    ensure      => $ensure_source,
-    location    => $location,
-    release     => $release,
-    repos       => $repos,
-    include     => { 'src' => $include_src },
-    key         => { 'id' => $key, 'source' => $key_source, 'content' =>  $key_content },
+    ensure       => $ensure_source,
+    location     => $location,
+    release      => $release,
+    repos        => $repos,
+    include      => { 'src' => $include_src },
+    key          => { 'id' => $key, 'source' => $key_source, 'content' =>  $key_content },
     architecture => $architecture,
   }
 

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -30,7 +30,11 @@ class rabbitmq::repo::apt(
     release      => $release,
     repos        => $repos,
     include      => { 'src' => $include_src },
-    key          => { 'id' => $key, 'source' => $key_source, 'content' =>  $key_content },
+    key          => {
+      'id'      => $key,
+      'source'  => $key_source,
+      'content' =>  $key_content
+    },
     architecture => $architecture,
   }
 

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -25,14 +25,12 @@ class rabbitmq::repo::apt(
   }
 
   apt::source { 'rabbitmq':
-    ensure       => $ensure_source,
-    location     => $location,
-    release      => $release,
-    repos        => $repos,
-    include_src  => $include_src,
-    key          => $key,
-    key_source   => $key_source,
-    key_content  => $key_content,
+    ensure      => $ensure_source,
+    location    => $location,
+    release     => $release,
+    repos       => $repos,
+    include     => { 'src' => $include_src },
+    key         => { 'id' => $key, 'source' => $key_source, 'content' =>  $key_content },
     architecture => $architecture,
   }
 

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1425,8 +1425,7 @@ LimitNOFILE=1234
           'location'    => 'http://www.rabbitmq.com/debian/',
           'release'     => 'testing',
           'repos'       => 'main',
-          'include_src' => false,
-          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          'key'         => '{"id"=>"0A9AF2115F4687BD29803A206B73A36E6026DFCA", "source"=>"https://www.rabbitmq.com/rabbitmq-release-signing-key.asc", "content"=>:undef}'
         ) }
       end
     end
@@ -1439,8 +1438,7 @@ LimitNOFILE=1234
           'location'    => 'http://www.rabbitmq.com/debian/',
           'release'     => 'testing',
           'repos'       => 'main',
-          'include_src' => false,
-          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          'key'         => '{"id"=>"0A9AF2115F4687BD29803A206B73A36E6026DFCA", "source"=>"https://www.rabbitmq.com/rabbitmq-release-signing-key.asc", "content"=>:undef}'
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
Puppetlabs Apt module now has deprecation warnings when call in the manner being used by the puppetlabs rabbitmq module. Updated and tested against puppetlabs apt module 2.2.2
