### PR TITLE
run "check_password" with retries

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -45,7 +45,9 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl, :parent => Puppet::Provi
 
 
   def check_password
-    response = rabbitmqctl('eval', 'rabbit_access_control:check_user_pass_login(list_to_binary("' + resource[:name] + '"), list_to_binary("' + resource[:password] +'")).')
+    response = self.class.run_with_retries {
+      rabbitmqctl('eval', 'rabbit_access_control:check_user_pass_login(list_to_binary("' + resource[:name] + '"), list_to_binary("' + resource[:password] +'")).')
+    }
     if response.include? 'refused'
         false
     else


### PR DESCRIPTION
On overloaded or slow systems after service starting there could be some temporary issues with requests to rabbit-server. To avoid such situations `run_with_retries` should also be used for checking password.