### PR TITLE
Allow Configuring Management IP Binding

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class rabbitmq::config {
   $env_config_path            = $rabbitmq::env_config_path
   $erlang_cookie              = $rabbitmq::erlang_cookie
   $interface                  = $rabbitmq::interface
+  $management_ip              = $rabbitmq::management_ip
   $management_port            = $rabbitmq::management_port
   $management_ssl             = $rabbitmq::management_ssl
   $management_hostname        = $rabbitmq::management_hostname

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class rabbitmq(
   $env_config_path            = $rabbitmq::params::env_config_path,
   $erlang_cookie              = $rabbitmq::params::erlang_cookie,
   $interface                  = $rabbitmq::params::interface,
+  $management_ip              = $rabbitmq::params::management_ip,
   $management_port            = $rabbitmq::params::management_port,
   $management_ssl             = $rabbitmq::params::management_ssl,
   $management_hostname        = $rabbitmq::params::management_hostname,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,6 +68,7 @@ class rabbitmq::params {
   #install
   $admin_enable                = true
   $management_hostname         = undef
+  $management_ip               = '0.0.0.0'
   $management_port             = '15672'
   $management_ssl              = true
   $package_apt_pin             = ''

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -90,6 +90,7 @@
 <%- if  !@config_management_variables.empty? -%>,<%-end-%>
     {listener, [
 <%- if @ssl && @management_ssl -%>
+      {ip, "<%= @management_ip %>"},
       {port, <%= @ssl_management_port %>},
       {ssl, true},
       {ssl_opts, [<%- if @ssl_cacert != 'UNSET' %>
@@ -108,10 +109,8 @@
                   <%- end -%>
                  ]}
 <%- else -%>
+      {ip, "<%= @management_ip %>"},
       {port, <%= @management_port %>}
-<%- end -%>
-<%- if @node_ip_address != 'UNSET' -%>
-      ,{ip, "<%= @node_ip_address %>"}
 <%- end -%>
     ]}
 <%- end -%>


### PR DESCRIPTION
This change allows users to change which IP address that the management web-server binds on.

This makes it possible to bind the management console on the local interface only, so that it can be proxied by e.g. NGINX and not be facing the public.