### PR TITLE
set $real_package_source to undef instead of empty

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -211,7 +211,7 @@ class rabbitmq(
         $real_package_source = undef
       }
       default: { # Archlinux and Debian
-        $real_package_source = ''
+        $real_package_source = undef
       }
     }
   } else { # for yum provider, use the source as is


### PR DESCRIPTION
This param is checked in install.pp:
https://github.com/puppetlabs/puppetlabs-rabbitmq/blob/master/manifests/install.pp#L19

The check doesn't work if the variable contains empty string.