### PR TITLE
fix test breakage

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,9 @@
 fixtures:
+  forge_modules:
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "4.12.0"
   repositories:
-    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
     "staging": "git://github.com/voxpupuli/puppet-staging.git"
     "erlang:": "git://github.com/garethr/garethr-erlang.git"


### PR DESCRIPTION
I'm not sure if this is intentional, but https://github.com/puppetlabs/puppetlabs-stdlib/commit/970852dd317fbb2699b406dd25aeddef496a7c92
seems to break the acceptance tests. @dhollinger helpfully suggested this fix; if stdlib is not going to be changed in a way that is backwards compatible for tests to at least run, we'll probably need to pin stdlib until the tests can be changed (maybe as part of the 6.0 release?)