### PR TITLE
[MODULES-3733] rabbitmq provider env_path does not locate ruby gem installed puppet binary

### DIFF
--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -4,14 +4,6 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
 
   defaultfor :feature => :posix
 
-  env_path = '/opt/puppetlabs/bin:/usr/local/bin:/usr/bin:/bin'
-  puppet_path = Puppet::Util.withenv(:PATH => env_path) do
-    Puppet::Util.which('puppet')
-  end
-
-  confine :false => puppet_path.nil?
-  has_command(:puppet, puppet_path) unless puppet_path.nil?
-
   def exists?
     # Hack to prevent the create method from being called.
     # We never need to create or destroy this resource, only change its value
@@ -20,7 +12,7 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
 
   def content=(value)
     if resource[:force] == :true # Danger!
-      puppet('resource', 'service', resource[:service_name], 'ensure=stopped')
+      Puppet::Type.type(:service).new(:name => resource[:service_name], :ensure => 'stopped')
       FileUtils.rm_rf(resource[:rabbitmq_home] + File::SEPARATOR + 'mnesia')
       File.open(resource[:path], 'w') do |cookie|
         cookie.chmod(0400)
@@ -28,7 +20,7 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
       end
       FileUtils.chown(resource[:rabbitmq_user], resource[:rabbitmq_group], resource[:path])
     else
-      fail("The current erlang cookie needs to change. In order to do this the RabbitMQ database needs to be wiped.  Please set force => true to allow this to happen automatically.")
+      fail('The current erlang cookie needs to change. In order to do this the RabbitMQ database needs to be wiped.  Please set force => true to allow this to happen automatically.')
     end
   end
 

--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
 
   def content=(value)
     if resource[:force] == :true # Danger!
-      Puppet::Type.type(:service).new(:name => resource[:service_name], :ensure => 'stopped')
+      Puppet::Type.type(:service).new(:name => resource[:service_name]).provider.stop
       FileUtils.rm_rf(resource[:rabbitmq_home] + File::SEPARATOR + 'mnesia')
       File.open(resource[:path], 'w') do |cookie|
         cookie.chmod(0400)


### PR DESCRIPTION
Change `rabbitmq_erlang_cookie` provider to call the puppet API instead of the puppet binary.