### PR TITLE
[MODULES-4223] don't set NODE_PORT and NODE_IP_ADDRESS if ssl_only

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,9 +65,14 @@ class rabbitmq::config {
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $file_limit                 = $rabbitmq::file_limit
   $collect_statistics_interval = $rabbitmq::collect_statistics_interval
-  $default_env_variables      =  {
-    'NODE_PORT'        => $port,
-    'NODE_IP_ADDRESS'  => $node_ip_address
+
+  if $ssl_only {
+    $default_env_variables = {}
+  } else {
+    $default_env_variables = {
+      'NODE_PORT'        => $port,
+      'NODE_IP_ADDRESS'  => $node_ip_address
+    }
   }
 
   # Handle env variables.

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -981,6 +981,11 @@ LimitNOFILE=1234
           should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
           should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
         end
+        it 'should not set TCP listener environment defaults' do
+          should contain_file('rabbitmq-env.config') \
+            .without_content(%r{NODE_PORT=}) \
+            .without_content(%r{NODE_IP_ADDRESS=})
+        end
       end
 
       describe 'ssl options with ssl_only and ssl_interfaces' do


### PR DESCRIPTION
These options are used for RabbitMQ to create a TCP listener, which is
not something we want if we are doing SSL-only. So these are not used as
defaults if that option is set.