### PR TITLE
Extend rabbitmqadmin config template with SSL options.

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -873,10 +873,13 @@ LimitNOFILE=1234
           should contain_file('rabbitmq.config').with_content(
             %r{port, 13142}
           )
+          should contain_file('rabbitmqadmin.conf').with_content(
+            %r{port\s=\s13142}
+          )
         end
       end
 
-        describe 'ssl options and mangament_ssl true' do
+      describe 'ssl options and mangament_ssl true' do
         let(:params) {
           { :ssl => true,
             :ssl_port => 3141,
@@ -910,6 +913,23 @@ LimitNOFILE=1234
         it 'should set ssl managment port to specified values' do
           should contain_file('rabbitmq.config').with_content(
             %r{port, 13141}
+          )
+        end
+        it 'should set ssl options in the rabbitmqadmin.conf' do
+          should contain_file('rabbitmqadmin.conf').with_content(
+            %r{ssl_ca_cert_file\s=\s/path/to/cacert}
+          )
+          should contain_file('rabbitmqadmin.conf').with_content(
+            %r{ssl_cert_file\s=\s/path/to/cert}
+          )
+          should contain_file('rabbitmqadmin.conf').with_content(
+            %r{ssl_key_file\s=\s/path/to/key}
+          )
+          should contain_file('rabbitmqadmin.conf').with_content(
+            %r{hostname\s=\s}
+          )
+          should contain_file('rabbitmqadmin.conf').with_content(
+            %r{port\s=\s13141}
           )
         end
       end

--- a/templates/rabbitmqadmin.conf.erb
+++ b/templates/rabbitmqadmin.conf.erb
@@ -1,7 +1,13 @@
 [default]
 <% if @ssl && @management_ssl -%>
 ssl = True
+ssl_ca_cert_file = <%= @ssl_cacert %>
+ssl_cert_file = <%= @ssl_cert %>
+ssl_key_file = <%= @ssl_key %>
 port = <%= @ssl_management_port %>
+<% unless @management_hostname -%>
+hostname = <%= @fqdn %>
+<% end -%>
 <% else -%>
 port = <%= @management_port %>
 <% end -%>


### PR DESCRIPTION
This PR fixes the issue, that when a recent RabbitMQ package is installed, the rabbitmqadmin fails to handle exchanges correctly if SSL is enabled and results in an error.

Therefore the `rabbitmqadmin.conf` template is extended with SSL options to match the CLI arguments of the rabbitmqadmin tool. In version 3.6.2 of the [rabbitmq-management](https://github.com/rabbitmq/rabbitmq-management) package, the admin tool changes its SSL support and incorporates new SSL arguments when communicating with the RabbitMQ server.  Alternatively the admin tool reads the arguments from a config file.

This config file is used as argument when instrumenting the rabbitmqadmin tool via this Puppet module (when declaring exchanges). The SSL options are only written to the config file when SSL is enabled. In case an earlier version of RabbitMQ is installed via this Puppet module these new options may still be set but are ignored by the admin tool and should not cause any errors.

* extend `rabbitmqadmin.conf` template with SSL options
* add tests to cover resulting config file