### PR TITLE
added ssl_depth and password params for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ Cert to use for SSL.
 
 Key to use for SSL.
 
+####`ssl_depth`
+
+SSL verification depth.
+
 ####`ssl_management_port`
 
 SSL management port.

--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ Cert to use for SSL.
 
 Key to use for SSL.
 
+####`ssl_cert_password`
+
+Password used when generating CSR.
+
 ####`ssl_depth`
 
 SSL verification depth.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class rabbitmq::config {
   $ssl_cert                   = $rabbitmq::ssl_cert
   $ssl_key                    = $rabbitmq::ssl_key
   $ssl_depth                  = $rabbitmq::ssl_depth
+  $ssl_cert_password          = $rabbitmq::ssl_cert_password
   $ssl_port                   = $rabbitmq::ssl_port
   $ssl_interface              = $rabbitmq::ssl_interface
   $ssl_management_port        = $rabbitmq::ssl_management_port

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@ class rabbitmq::config {
   $ssl_cacert                 = $rabbitmq::ssl_cacert
   $ssl_cert                   = $rabbitmq::ssl_cert
   $ssl_key                    = $rabbitmq::ssl_key
+  $ssl_depth                  = $rabbitmq::ssl_depth
   $ssl_port                   = $rabbitmq::ssl_port
   $ssl_interface              = $rabbitmq::ssl_interface
   $ssl_management_port        = $rabbitmq::ssl_management_port

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class rabbitmq(
   $ssl_cacert                 = $rabbitmq::params::ssl_cacert,
   $ssl_cert                   = $rabbitmq::params::ssl_cert,
   $ssl_key                    = $rabbitmq::params::ssl_key,
+  $ssl_depth                  = $rabbitmq::params::ssl_depth,
   $ssl_port                   = $rabbitmq::params::ssl_port,
   $ssl_interface              = $rabbitmq::params::ssl_interface,
   $ssl_management_port        = $rabbitmq::params::ssl_management_port,
@@ -140,6 +141,9 @@ class rabbitmq(
   validate_string($ssl_cacert)
   validate_string($ssl_cert)
   validate_string($ssl_key)
+  if ! is_integer($ssl_depth) {
+    validate_re($ssl_depth, '\d+')
+  }  
   validate_array($ssl_ciphers)
   if ! is_integer($ssl_port) {
     validate_re($ssl_port, '\d+')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,9 +142,7 @@ class rabbitmq(
   validate_string($ssl_cacert)
   validate_string($ssl_cert)
   validate_string($ssl_key)
-  if ! is_integer($ssl_depth) {
-    validate_re($ssl_depth, '\d+')
-  }  
+  validate_integer($ssl_depth, '\d+')
   validate_string(ssl_cert_password)
   validate_array($ssl_ciphers)
   if ! is_integer($ssl_port) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class rabbitmq(
   $ssl_cert                   = $rabbitmq::params::ssl_cert,
   $ssl_key                    = $rabbitmq::params::ssl_key,
   $ssl_depth                  = $rabbitmq::params::ssl_depth,
+  $ssl_cert_password          = $rabbitmq::params::ssl_cert_password,
   $ssl_port                   = $rabbitmq::params::ssl_port,
   $ssl_interface              = $rabbitmq::params::ssl_interface,
   $ssl_management_port        = $rabbitmq::params::ssl_management_port,
@@ -144,6 +145,7 @@ class rabbitmq(
   if ! is_integer($ssl_depth) {
     validate_re($ssl_depth, '\d+')
   }  
+  validate_string(ssl_cert_password)
   validate_array($ssl_ciphers)
   if ! is_integer($ssl_port) {
     validate_re($ssl_port, '\d+')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,7 +142,9 @@ class rabbitmq(
   validate_string($ssl_cacert)
   validate_string($ssl_cert)
   validate_string($ssl_key)
-  validate_integer($ssl_depth)
+  if $ssl_depth {
+    validate_integer($ssl_depth)
+  }
   validate_string($ssl_cert_password)
   validate_array($ssl_ciphers)
   if ! is_integer($ssl_port) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,8 +142,8 @@ class rabbitmq(
   validate_string($ssl_cacert)
   validate_string($ssl_cert)
   validate_string($ssl_key)
-  validate_integer($ssl_depth, '\d+')
-  validate_string(ssl_cert_password)
+  validate_integer($ssl_depth)
+  validate_string($ssl_cert_password)
   validate_array($ssl_ciphers)
   if ! is_integer($ssl_port) {
     validate_re($ssl_port, '\d+')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,6 +104,7 @@ class rabbitmq::params {
   $ssl_cacert                  = 'UNSET'
   $ssl_cert                    = 'UNSET'
   $ssl_key                     = 'UNSET'
+  $ssl_depth                   = 'UNSET'
   $ssl_port                    = '5671'
   $ssl_interface               = 'UNSET'
   $ssl_management_port         = '15671'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -105,7 +105,7 @@ class rabbitmq::params {
   $ssl_cert                    = 'UNSET'
   $ssl_key                     = 'UNSET'
   $ssl_depth                   = 'UNSET'
-  $ssl_cert_password           = 'UNSET'
+  $ssl_cert_password           = undef
   $ssl_port                    = '5671'
   $ssl_interface               = 'UNSET'
   $ssl_management_port         = '15671'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,7 +104,7 @@ class rabbitmq::params {
   $ssl_cacert                  = 'UNSET'
   $ssl_cert                    = 'UNSET'
   $ssl_key                     = 'UNSET'
-  $ssl_depth                   = 'UNSET'
+  $ssl_depth                   = undef
   $ssl_cert_password           = undef
   $ssl_port                    = '5671'
   $ssl_interface               = 'UNSET'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -105,6 +105,7 @@ class rabbitmq::params {
   $ssl_cert                    = 'UNSET'
   $ssl_key                     = 'UNSET'
   $ssl_depth                   = 'UNSET'
+  $ssl_cert_password           = 'UNSET'
   $ssl_port                    = '5671'
   $ssl_interface               = 'UNSET'
   $ssl_management_port         = '15671'

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -57,6 +57,9 @@
                    <%- end -%>
                    {certfile,"<%= @ssl_cert %>"},
                    {keyfile,"<%= @ssl_key %>"},
+                   <%- if @ssl_cert_password != 'UNSET' -%>
+                   {password, "<%= @ssl_cert_password %>"},
+                   <%- end -%>
                    <%- if @ssl_depth != 'UNSET' -%>
                    {depth,<%= @ssl_depth %>},
                    <%- end -%>

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -57,6 +57,9 @@
                    <%- end -%>
                    {certfile,"<%= @ssl_cert %>"},
                    {keyfile,"<%= @ssl_key %>"},
+                   <%- if @ssl_depth != 'UNSET' -%>
+                   {depth,<%= @ssl_depth %>},
+                   <%- end -%>
                    {verify,<%= @ssl_verify %>},
                    {fail_if_no_peer_cert,<%= @ssl_fail_if_no_peer_cert %>}
                    <%- if @ssl_versions -%>


### PR DESCRIPTION
Add the option to provide the "depth" configuration option in the rabbitmq.config for SSL validation depth.

Puppetlabs ticket MODULES-4408