### PR TITLE
(maint) parallel_spec maintenance: spec_helper

### DIFF
--- a/spec/unit/puppet/type/rabbitmq_binding_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_binding_spec.rb
@@ -1,5 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_binding'
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_binding) do
   before :each do
     @binding = Puppet::Type.type(:rabbitmq_binding).new(

--- a/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
@@ -1,5 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_exchange'
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_exchange) do
   before :each do
     @exchange = Puppet::Type.type(:rabbitmq_exchange).new(

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -1,6 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_parameter'
-
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_parameter) do
 
   before do

--- a/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
@@ -1,5 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_plugin'
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_plugin) do
   before :each do
     @plugin = Puppet::Type.type(:rabbitmq_plugin).new(:name => 'foo')

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -1,6 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_policy'
-
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_policy) do
 
   before do

--- a/spec/unit/puppet/type/rabbitmq_queue_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_queue_spec.rb
@@ -1,6 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_queue'
-require 'json'
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_queue) do
   before :each do
     @queue = Puppet::Type.type(:rabbitmq_queue).new(

--- a/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
@@ -1,5 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_user_permissions'
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_user_permissions) do
   before :each do
     @perms = Puppet::Type.type(:rabbitmq_user_permissions).new(:name => 'foo@bar')

--- a/spec/unit/puppet/type/rabbitmq_user_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_spec.rb
@@ -1,5 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_user'
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_user) do
   before :each do
     @user = Puppet::Type.type(:rabbitmq_user).new(:name => 'foo', :password => 'pass')

--- a/spec/unit/puppet/type/rabbitmq_vhost_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_vhost_spec.rb
@@ -1,5 +1,4 @@
-require 'puppet'
-require 'puppet/type/rabbitmq_vhost'
+require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_vhost) do
   before :each do
     @vhost = Puppet::Type.type(:rabbitmq_vhost).new(:name => 'foo')


### PR DESCRIPTION
the parallel_spec that is run on travis revealed a dependency issue in the user_permissions_spec. none of the type unit tests were using the spec_helper and were requiring puppet and their respective types explicitly. this reverses that by requiring the spec_helper and removing the other dependencies and in turn repairing the failures.

this is causing travis to fail needlessly on all PRs currently.