### PR TITLE
[MODULES-4450] don't set ssl depth if undef

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -62,7 +62,7 @@
                    <%- if @ssl_cert_password != 'UNSET' -%>
                    {password, "<%= @ssl_cert_password %>"},
                    <%- end -%>
-                   <%- if @ssl_depth != 'UNSET' -%>
+                   <%- if @ssl_depth -%>
                    {depth,<%= @ssl_depth %>},
                    <%- end -%>
                    {verify,<%= @ssl_verify %>},


### PR DESCRIPTION
As per a recent commit [1], the default value of ssl_depth is undef.
This turned out problematic, as the template checks for 'UNSET', and
validation of this parameter is only done if the ssl_depth was set to
something (remember it defaults to undef). So, using the default value
results in an invalid rabbitmq configuration, which breaks with a syntax
error.

This sets the check in the template to work only if the value of that
variable is set (so it won't write it if the default undef is used).

[1] https://github.com/puppetlabs/puppetlabs-rabbitmq/commit/21ac01e4a1835604e9ffaaedbef024fd2ea9a0f4