### PR TITLE
Systemd open files limit

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -143,7 +143,7 @@ class rabbitmq::config {
           notify  => Exec['rabbitmq-systemd-reload'],
         }
         exec { 'rabbitmq-systemd-reload':
-          command     => '/usr/bin/systemctl daemon-reload',
+          command     => '/bin/systemctl daemon-reload',
           notify      => Class['Rabbitmq::Service'],
           refreshonly => true,
         }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -127,6 +127,27 @@ class rabbitmq::config {
 
   case $::osfamily {
     'Debian': {
+      if versioncmp($::operatingsystemmajrelease, '16.04') >= 0 {
+        file { '/etc/systemd/system/rabbitmq-server.service.d':
+          ensure                  => directory,
+          owner                   => '0',
+          group                   => '0',
+          mode                    => '0755',
+          selinux_ignore_defaults => true,
+        } ->
+        file { '/etc/systemd/system/rabbitmq-server.service.d/limits.conf':
+          content => template('rabbitmq/rabbitmq-server.service.d/limits.conf'),
+          owner   => '0',
+          group   => '0',
+          mode    => '0644',
+          notify  => Exec['rabbitmq-systemd-reload'],
+        }
+        exec { 'rabbitmq-systemd-reload':
+          command     => '/usr/bin/systemctl daemon-reload',
+          notify      => Class['Rabbitmq::Service'],
+          refreshonly => true,
+        }
+      }
       file { '/etc/default/rabbitmq-server':
         ensure  => file,
         content => template('rabbitmq/default.erb'),


### PR DESCRIPTION
This basically copies CentOS approach and increases Ubuntu 16.04 compatibility by creating /etc/systemd/system/rabbitmq-server.service.d/limits.conf file