### PR TITLE
Scope config_variables for Puppet 4

### DIFF
--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -77,9 +77,9 @@
                    <%- end -%>
                   ]},
 <%- end -%>
-<% if @config_variables -%>
-<%- @config_variables.keys.sort.each do |key| -%>
-    {<%= key %>, <%= @config_variables[key] %>},
+<% if scope['rabbitmq::config_variables'] -%>
+<%- scope['rabbitmq::config_variables'].keys.sort.each do |key| -%>
+    {<%= key %>, <%= scope['rabbitmq::config_variables'][key] %>},
 <%- end -%>
 <%- end -%>
     {default_user, <<"<%= @default_user %>">>},


### PR DESCRIPTION
This looks up the `config_variables` input parameter using `scope` in the `rabbitmq.config.erb` template so that it works with Puppet 4.