### PR TITLE
Update regexp for rabbitmq_nodename fact

### DIFF
--- a/lib/facter/rabbitmq_nodename.rb
+++ b/lib/facter/rabbitmq_nodename.rb
@@ -2,7 +2,7 @@ Facter.add(:rabbitmq_nodename) do
   setcode do
     if Facter::Core::Execution.which('rabbitmqctl')
       rabbitmq_nodename = Facter::Core::Execution.execute('rabbitmqctl status 2>&1')
-      %r{^Status of node '?([\w\.]+@[\w\.\-]+)'? \.+$}.match(rabbitmq_nodename)[1]
+      %r{^Status of node '?([\w\.]+@[\w\.\-]+)'?}.match(rabbitmq_nodename)[1]
     end
   end
 end

--- a/spec/unit/rabbitmq_nodename_spec.rb
+++ b/spec/unit/rabbitmq_nodename_spec.rb
@@ -35,5 +35,16 @@ describe Facter::Util::Fact do
         expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
       }
     end
+
+    context 'without trailing points' do
+      before :each do
+        Facter::Core::Execution.stubs(:which).with('rabbitmqctl').returns(true)
+        Facter::Core::Execution.stubs(:execute).with('rabbitmqctl status 2>&1').returns('Status of node monty@rabbit-1')
+      end
+      it {
+        expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
+      }
+    end
+
   end
 end


### PR DESCRIPTION
rabbitmqctl status returns node status without trailing points
on rabbitmq: 3.6.10, e.g:
   root@rabbitmq:~# rabbitmqctl status
     Status of node rabbit@rabbitmq
     [{pid,16527},
       ....

So let's align regexp as well