### PR TITLE
[Fix CI] pin puppetlabs-apt fixture version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
+    "apt":
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      ref: "4.0.0"
     "staging": "git://github.com/voxpupuli/puppet-staging.git"
     "erlang:": "git://github.com/garethr/garethr-erlang.git"
   symlinks:


### PR DESCRIPTION
Latest changes in puppetlabs-apt master branch [1] breaks current CI.
This change fixes CI by pinning puppetlabs-apt to tag: 4.0.0

[1]. https://github.com/puppetlabs/puppetlabs-apt/pull/680