### PR TITLE
Improve distro fact handling in tests

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -396,26 +396,9 @@ LimitNOFILE=1234
   end
 
   ['Debian', 'RedHat', 'SUSE', 'Archlinux'].each do |distro|
-    osfacts = {
-      :osfamily         => distro,
-      :staging_http_get => '',
-      :puppetversion    => Puppet.version,
-    }
-
-    case distro
-    when 'Debian'
-      osfacts.merge!({
-        :lsbdistcodename => 'squeeze',
-        :lsbdistid       => 'Debian'
-      })
-    when 'RedHat'
-      osfacts.merge!({
-        :operatingsystemmajrelease => '7',
-      })
-    end
 
     context "on #{distro}" do
-      let(:facts) { osfacts }
+      with_distro_facts distro
 
       it { should contain_class('rabbitmq::install') }
       it { should contain_class('rabbitmq::config') }
@@ -1365,7 +1348,7 @@ LimitNOFILE=1234
   end
 
   context "on Archlinux" do
-    let(:facts) {{ :osfamily => 'Archlinux', :staging_http_get => ''}}
+    with_archlinux_facts
     it 'installs the rabbitmq package' do
       should contain_package('rabbitmq-server').with(
         'ensure'   => 'installed',
@@ -1422,26 +1405,10 @@ LimitNOFILE=1234
   end
 
   ['RedHat', 'SuSE'].each do |distro|
-    osfacts = {
-      :osfamily         => distro,
-      :staging_http_get => ''
-    }
-
-    case distro
-    when 'Debian'
-      osfacts.merge!({
-        :lsbdistcodename => 'squeeze',
-        :lsbdistid => 'Debian'
-      })
-    when 'RedHat'
-      osfacts.merge!({
-        :operatingsystemmajrelease => '7',
-      })
-    end
 
     describe "repo management on #{distro}" do
       describe 'imports the key' do
-        let(:facts) { osfacts }
+        with_distro_facts distro
         let(:params) {{ :package_gpg_key => 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc' }}
 
         it { should contain_exec("rpm --import #{params[:package_gpg_key]}").with(

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,5 +1,6 @@
 RSpec.shared_context "default facts" do
-  let(:facts) { { :puppetversion => Puppet.version, } }
+  let(:facts) { { :puppetversion    => Puppet.version,
+                  :staging_http_get => ''} }
 end
 
 RSpec.configure do |rspec|
@@ -12,7 +13,8 @@ def with_debian_facts
       :lsbdistcodename  => 'squeeze',
       :lsbdistid        => 'Debian',
       :osfamily         => 'Debian',
-      :staging_http_get => '',
+      :os               => { :name => 'Debian',
+                             :release => { :full => '6.0'} },
     })
   end
 end
@@ -25,7 +27,6 @@ def with_openbsd_facts
     super().merge({
       :kernelversion             => '5.9',
       :osfamily                  => 'OpenBSD',
-      :staging_http_get          => '',
     })
   end
 end
@@ -35,7 +36,22 @@ def with_redhat_facts
     super().merge({
       :operatingsystemmajrelease => '7',
       :osfamily                  => 'Redhat',
-      :staging_http_get          => '',
     })
   end
+end
+
+def with_suse_facts
+  let :facts do
+    super().merge({ :osfamily => 'SUSE' })
+  end
+end
+
+def with_archlinux_facts
+  let :facts do
+    super().merge({ :osfamily => 'Archlinux' })
+  end
+end
+
+def with_distro_facts(distro)
+  send("with_#{distro.downcase}_facts")
 end


### PR DESCRIPTION
This makes things a bit more consistent, and also fixes test failures
due to newer puppetlabs-apt module requiring items under $facts['os']